### PR TITLE
Allow use of logfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@ and `<app-name>` with the name of the application on Heroku.
 You're done!
 
 If you decide to use Timber in your local development environment, you will want
-to turn on the `print_timestamps` and `print_log_level` options so you can see
-your logs nicely in your terminal window:
+to turn on the `colorize`, `print_timestamps`, and `print_log_level` options so
+you can see your logs nicely in your terminal window. It will also help to
+set `format` to `:logfmt`:
 
 ```
-config :timber, :transport_config,
-  print_timestamps: false,
-  print_log_level: false
+# config/dev.exs
+
+config :timber, :io_device,
+  colorize: true,
+  format: :logfmt,
+  print_timestamps: true
+  print_log_level: true
 ```
 
 ## Events and Context

--- a/lib/timber/logfmt_encoder.ex
+++ b/lib/timber/logfmt_encoder.ex
@@ -1,0 +1,33 @@
+defmodule Timber.LogfmtEncoder do
+  @moduledoc false
+  # Internal module for encoding maps to the logfmt standard
+
+  @spec encode!(map) :: IO.chardata
+  def encode!(value) when is_map(value) do
+    Enum.reduce(value, [], &encode_pair/2)
+  end
+
+  defp encode_pair({k1, value_map}, acc) when is_map(value_map) do
+    Enum.reduce(value_map, acc, fn ({k2, v}, a) ->
+      encode_pair({[to_string(k1), ?., to_string(k2)], v}, a)
+    end)
+  end
+
+  defp encode_pair({key, values}, acc) when is_list(values) do
+    Enum.reduce(values, acc, fn (value, a)->
+      add_key_value(key, value, a)
+    end)
+  end
+
+  defp encode_pair({key, value}, acc) do
+    add_key_value(key, value, acc)
+  end
+
+  defp add_key_value(key, value, []) do
+    [to_string(key), ?=, to_string(value)]
+  end
+
+  defp add_key_value(key, value, acc) do
+    [to_string(key), ?=, to_string(value), ?\s | acc]
+  end
+end

--- a/lib/timber/logger.ex
+++ b/lib/timber/logger.ex
@@ -84,9 +84,8 @@ defmodule Timber.Logger do
   @spec init(Elixir.Timber.Logger) :: {:ok, t}
   def init(__MODULE__) do
     transport = get_transport()
-    transport_config = get_transport_config()
 
-    {:ok, transport_state} = transport.init(transport_config)
+    {:ok, transport_state} = transport.init()
 
     state = %__MODULE__{
       transport: transport,
@@ -207,12 +206,5 @@ defmodule Timber.Logger do
   @spec get_transport() :: module
   defp get_transport() do
     Application.get_env(:timber, :transport)
-  end
-
-  # Gets the transport configuration by looking up the value in the Application
-  # configuration
-  @spec get_transport_config() :: Keyword.t
-  defp get_transport_config() do
-    Application.get_env(:timber, :transport_config, [])
   end
 end

--- a/lib/timber/transport.ex
+++ b/lib/timber/transport.ex
@@ -27,12 +27,12 @@ defmodule Timber.Transport do
   @callback flush(state) :: state
 
   @doc """
-  Initializes the transport with the provided configuration
+  Initializes the transport
 
   The transport is expected to start any necessary processes at this point. References
   to other processes should be kept in the state which is then returned.
   """
-  @callback init(Keyword.t) :: {:ok, state} | no_return
+  @callback init() :: {:ok, state} | no_return
 
   @doc """
   Writes a log message to the transport

--- a/lib/timber/utils.ex
+++ b/lib/timber/utils.ex
@@ -13,6 +13,8 @@ defmodule Timber.Utils do
   def drop_nil_values(map) do
     Enum.reject(map, fn
       {_k, nil} -> true
+      {_k, []} -> true
+      {_k, m} when is_map(m) and map_size(m) == 0 -> true
       _ -> false
     end)
     |> Enum.into(%{})

--- a/mix.exs
+++ b/mix.exs
@@ -69,9 +69,7 @@ defmodule Timber.Mixfile do
   # The environment to be configured by default
   defp env() do
     [
-      timber: [
-        transport: Timber.Transports.IODevice
-      ]
+      transport: Timber.Transports.IODevice,
     ]
   end
 


### PR DESCRIPTION
- Configuration for the `IODevice` transport has been moved to the `:timber, :io_device` namespace from the `:timber, :transport_config` namespace
- For _development_, you can now output logs in logfmt using `config :timber, :io_device, format: :logfmt`
- The `:hide_context` option has been deprecated in favor of the new `:print_metadata` option
