### PR TITLE
Remove advanced custom event usage

### DIFF
--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -41,14 +41,11 @@ defmodule Timber do
   # This is the function that starts up the error logger listener
   #
   def start(_type, _opts) do
-    capture_errors = Application.get_env(:timber, :capture_errors, false)
-    disable_tty = Application.get_env(:timber, :disable_kernel_error_tty, capture_errors)
-
-    if capture_errors do
+    if Timber.Config.capture_errors?() do
       :error_logger.add_report_handler(Timber.ErrorLogger)
     end
 
-    if disable_tty do
+    if Timber.Config.disable_tty?() do
       :error_logger.tty(false)
     end
 

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -21,7 +21,7 @@ defmodule Timber do
   @spec add_context(Context.context_data) :: :ok
   def add_context(data) do
     current_metadata = Elixir.Logger.metadata()
-    current_context = Keyword.get(current_metadata, :timber_context, %{})
+    current_context = Keyword.get(current_metadata, :timber_context, Context.new())
     new_context = Context.add_context(current_context, data)
 
     Elixir.Logger.metadata([timber_context: new_context])

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -1,0 +1,23 @@
+defmodule Timber.Config do
+  @env_key :timber
+
+  def capture_errors?(),
+    do: Application.get_env(@env_key, :capture_errors, false)
+
+  def disable_tty?(),
+    do: Application.get_env(@env_key, :disable_kernel_error_tty, capture_errors?())
+
+  def event_key(),
+    do: Application.get_env(@env_key, :event_key, :event)
+
+  def io_device(),
+    do: Application.get_env(@env_key, :io_device, [])
+
+  @spec phoenix_instrumentation_level(atom) :: atom
+  def phoenix_instrumentation_level(default) do
+    Application.get_env(@env_key, :instrumentation_level, default)
+  end
+
+  def transport(),
+    do: Application.get_env(@env_key, :transport)
+end

--- a/lib/timber/context.ex
+++ b/lib/timber/context.ex
@@ -26,6 +26,9 @@ defmodule Timber.Context do
     optional(:user) => Context.UserContext.m
   }
 
+  @doc false
+  def new(), do: %{}
+
   @doc """
   Takes an existing context and inserts the new context
   """
@@ -42,7 +45,6 @@ defmodule Timber.Context do
   defp insert_context(new_context, existing_context, _key) when map_size(new_context) == 0 do
     existing_context
   end
-
   defp insert_context(new_context, existing_context, key) do
     Map.put(existing_context, key, new_context)
   end

--- a/lib/timber/context.ex
+++ b/lib/timber/context.ex
@@ -33,6 +33,14 @@ defmodule Timber.Context do
   Takes an existing context and inserts the new context
   """
   @spec add_context(t, context_data) :: t
+  def add_context(existing_context_map, %Contexts.CustomContext{type: type, data: data} = context_element) do
+    key = type_for_data(context_element)
+    custom_map =
+      existing_context_map
+      |> Map.get(key, %{})
+      |> Map.put(type, data)
+    Map.put(existing_context_map, key, custom_map)
+  end
   def add_context(existing_context_map, context_element) do
     key = type_for_data(context_element)
 

--- a/lib/timber/contexts/custom_context.ex
+++ b/lib/timber/contexts/custom_context.ex
@@ -5,17 +5,27 @@ defmodule Timber.Contexts.CustomContext do
 
   You can use a custom context to track contextual information relevant to your
   system that is not one of the commonly supported contexts for Timber.
+
+  ## Fields
+
+    * `type` - (atom, required) This is the type of your context. It should be something unique
+      and unchanging. It will be used to identify this content. Example: `:my_context`.
+    * `data` - (map, optional) A map of data. This can be anything that implements the
+      `Poison.Encoder` protocol. That is, anything that can be JSON encoded.
+      Example: `%{key: "value"}`.
+
   """
 
   @type t :: %__MODULE__{
-    name: atom(),
+    type: atom(),
     data: %{String.t => any}
   }
 
   @type m :: %{
-    name: atom(),
+    type: atom(),
     data: %{String.t => any}
   }
 
-  defstruct [:name, :data]
+  @enforce_keys [:type]
+  defstruct [:type, :data]
 end

--- a/lib/timber/contexts/custom_context.ex
+++ b/lib/timber/contexts/custom_context.ex
@@ -8,7 +8,12 @@ defmodule Timber.Contexts.CustomContext do
   """
 
   @type t :: %__MODULE__{
-    name: String.t,
+    name: atom(),
+    data: %{String.t => any}
+  }
+
+  @type m :: %{
+    name: atom(),
     data: %{String.t => any}
   }
 

--- a/lib/timber/contexts/custom_context.ex
+++ b/lib/timber/contexts/custom_context.ex
@@ -14,6 +14,11 @@ defmodule Timber.Contexts.CustomContext do
       `Poison.Encoder` protocol. That is, anything that can be JSON encoded.
       Example: `%{key: "value"}`.
 
+  ## Example
+
+    %Timber.Contexts.CustomContext{type: :my_custom_context, data: %{"key" => "value"}}
+    |> Timber.add_context()
+
   """
 
   @type t :: %__MODULE__{

--- a/lib/timber/contexts/organization_context.ex
+++ b/lib/timber/contexts/organization_context.ex
@@ -13,5 +13,10 @@ defmodule Timber.Contexts.OrganizationContext do
     name: String.t
   }
 
+  @type m :: %{
+    id: String.t,
+    name: String.t
+  }
+
   defstruct [:id, :name]
 end

--- a/lib/timber/contexts/process_context.ex
+++ b/lib/timber/contexts/process_context.ex
@@ -8,6 +8,11 @@ defmodule Timber.Contexts.ProcessContext do
     description: String.t
   }
 
+  @type m :: %{
+    id: String.t,
+    description: String.t
+  }
+
   defstruct [:id, :description]
 
   def new(opts) do

--- a/lib/timber/contexts/server_context.ex
+++ b/lib/timber/contexts/server_context.ex
@@ -7,5 +7,9 @@ defmodule Timber.Contexts.ServerContext do
     hostname: String.t
   }
 
+  @type m :: %{
+    hostname: String.t
+  }
+
   defstruct [:hostname]
 end

--- a/lib/timber/contexts/user_context.ex
+++ b/lib/timber/contexts/user_context.ex
@@ -9,6 +9,12 @@ defmodule Timber.Contexts.UserContext do
     email: String.t
   }
 
+  @type m :: %{
+    id: String.t,
+    name: String.t,
+    email: String.t
+  }
+
   defstruct [:id, :name, :email]
 
   def new(opts) do

--- a/lib/timber/ecto.ex
+++ b/lib/timber/ecto.ex
@@ -78,7 +78,10 @@ defmodule Timber.Ecto do
       time_ms: time_ms
     )
 
-    Logger.log(level, SQLQueryEvent.message(event), timber_event: event)
+    message = SQLQueryEvent.message(event)
+    metadata = Timber.Event.metadata(event)
+
+    Logger.log(level, message, metadata)
 
     entry
   end

--- a/lib/timber/error_logger.ex
+++ b/lib/timber/error_logger.ex
@@ -87,7 +87,13 @@ defmodule Timber.ErrorLogger do
           |> Keyword.get(:dictionary)
           |> handle_process_dictionary()
 
-        Logger.error(ExceptionEvent.message(event), [timber_context: context, timber_event: event])
+        message = ExceptionEvent.message(event)
+        metadata =
+          event
+          |> Timber.Event.metadata()
+          |> Keyword.put(:timber_context, context)
+
+        Logger.error(message, metadata)
       {:error, _} ->
         # do nothing
         :ok
@@ -98,7 +104,11 @@ defmodule Timber.ErrorLogger do
 
   def handle_event({:error, _gl, {_process, _msg_fmt, [_pid, {error, stacktrace}]}}, state) do
     event = ExceptionEvent.new(error, stacktrace)
-    Logger.error(ExceptionEvent.message(event), timber_event: event)
+
+    message = ExceptionEvent.message(event)
+    metadata = Timber.Event.metadata(event)
+
+    Logger.error(message, metadata)
 
     {:ok, state}
   end

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -4,6 +4,8 @@ defmodule Timber.Event do
   implements the `Timber.Eventable` protocol.
   """
 
+  alias Timber.{Eventable, Events}
+
   @type t ::
     Events.ControllerCallEvent  |
     Events.CustomEvent          |
@@ -13,62 +15,27 @@ defmodule Timber.Event do
     Events.SQLQueryEvent        |
     Events.TemplateRenderEvent
 
-  @type message :: IO.chardata
-  @type metadata :: [timber_event: Timber.Eventable.t]
-
-  @callback message(t) :: message
-
   @doc """
-  Extracts the message from the event.
-
-  Using custom events? Simple define a `message/1` method or add a `:message` attribute.
+  Converts the given event to a map in the structure that the Timber API
+  expects during ingestion.
   """
-  @spec message(Timber.Eventable.t) :: message
-  def message(data) do
-    event = Timber.Eventable.to_event(data)
-    event.__struct__.message(event)
-  end
-
-  @doc """
-  Convenience method for keying the metadata with `:timber_event`.
-  """
-  @spec metadata(Timber.Eventable.t) :: metadata
-  def metadata(data) do
-    [timber_event: data]
-  end
-
-  @doc """
-  Convenience method for getting the message and metadata in one call.
-
-    ```
-    require Logger
-    {message, metdata} = Timber.Event.logger_tuple(data)
-    Logger.info(message, metdata)
-    ```
-
-  This is equivalent to:
-
-    ```
-    require Logger
-    event = Timber.Eventable.to_event(data)
-    message = Timber.Event.message(event)
-    Logger.info(message, timber_event: event)
-    ```
-
-  In future versions of Elixir, a logger passed function can return this tuple.
-  See https://github.com/elixir-lang/elixir/pull/5447. Once available, you'll be
-  able to do:
-
-    ```
-    # Warning, the below code will not work until the above PR is released!
-    require Logger
-    Logger.info fn -> Timber.Event.logger_tuple(event) end
-    ```
-
-  """
-  @spec logger_tuple(Timber.Eventable.t) :: {message, metadata}
-  def logger_tuple(data) do
-    event = Timber.Eventable.to_event(data)
-    {message(event), metadata(event)}
+  def to_api_map(%Events.ControllerCallEvent{} = event),
+    do: %{type: :controller_call, data: Map.from_struct(event)}
+  def to_api_map(%Events.CustomEvent{name: name, data: data} = event),
+    do: %{type: :custom, name: name, data: data}
+  def to_api_map(%Events.ExceptionEvent{} = event),
+    do: %{type: :exception, data: Map.from_struct(event)}
+  def to_api_map(%Events.HTTPRequestEvent{} = event),
+    do: %{type: :http_request, data: Map.from_struct(event)}
+  def to_api_map(%Events.HTTPResponseEvent{} = event),
+    do: %{type: :http_response, data: Map.from_struct(event)}
+  def to_api_map(%Events.SQLQueryEvent{} = event),
+    do: %{type: :sql_query, data: Map.from_struct(event)}
+  def to_api_map(%Events.TemplateRenderEvent{} = event),
+    do: %{type: :template_render, data: Map.from_struct(event)}
+  def to_api_map(eventable) do
+    eventable
+    |> Eventable.to_event()
+    |> to_api_map()
   end
 end

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -18,28 +18,4 @@ defmodule Timber.Event do
   def metadata(event) do
     Keyword.put([], Timber.Config.event_key(), event]
   end
-
-  @doc """
-  Converts the given event to a map in the structure that the Timber API
-  expects during ingestion.
-  """
-  def to_api_map(%Events.ControllerCallEvent{} = event),
-    do: %{type: :controller_call, data: Map.from_struct(event)}
-  def to_api_map(%Events.CustomEvent{name: name, data: data} = event),
-    do: %{type: :custom, name: name, data: data}
-  def to_api_map(%Events.ExceptionEvent{} = event),
-    do: %{type: :exception, data: Map.from_struct(event)}
-  def to_api_map(%Events.HTTPRequestEvent{} = event),
-    do: %{type: :http_request, data: Map.from_struct(event)}
-  def to_api_map(%Events.HTTPResponseEvent{} = event),
-    do: %{type: :http_response, data: Map.from_struct(event)}
-  def to_api_map(%Events.SQLQueryEvent{} = event),
-    do: %{type: :sql_query, data: Map.from_struct(event)}
-  def to_api_map(%Events.TemplateRenderEvent{} = event),
-    do: %{type: :template_render, data: Map.from_struct(event)}
-  def to_api_map(eventable) do
-    eventable
-    |> Eventable.to_event()
-    |> to_api_map()
-  end
 end

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -15,6 +15,10 @@ defmodule Timber.Event do
     Events.SQLQueryEvent        |
     Events.TemplateRenderEvent
 
+  def metadata(event) do
+    Keyword.put([], Timber.Config.event_key(), event]
+  end
+
   @doc """
   Converts the given event to a map in the structure that the Timber API
   expects during ingestion.

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -16,6 +16,6 @@ defmodule Timber.Event do
     Events.TemplateRenderEvent
 
   def metadata(event) do
-    Keyword.put([], Timber.Config.event_key(), event]
+    Keyword.put([], Timber.Config.event_key(), event)
   end
 end

--- a/lib/timber/event_plug.ex
+++ b/lib/timber/event_plug.ex
@@ -121,7 +121,10 @@ defmodule Timber.EventPlug do
       query_params: query_params
     )
 
-    Logger.log(log_level, HTTPRequestEvent.message(event), timber_event: event)
+    message = HTTPRequestEvent.message(event)
+    metadata = Timber.Event.metadata(event)
+
+    Logger.log(log_level, message, metadata)
 
     Plug.Conn.put_private(conn, :timber_opts, opts)
     |> Plug.Conn.put_private(:timber_start, start)
@@ -151,7 +154,10 @@ defmodule Timber.EventPlug do
       time_ms: time_ms
     )
 
-    Logger.log(log_level, HTTPResponseEvent.message(event), timber_event: event)
+    message = HTTPResponseEvent.message(event)
+    metadata = Timber.Event.metadata(event)
+
+    Logger.log(log_level, message, metadata)
 
     conn
   end

--- a/lib/timber/eventable.ex
+++ b/lib/timber/eventable.ex
@@ -15,7 +15,7 @@ defprotocol Timber.Eventable do
   ## Using Timber.Events.CustomEvent
 
     iex> require Logger
-    iex> event = Timber.Events.CustomEvent.new(name: :payment_rejected, data: %{customer_id: "xiaus1934", amount: 1900, currency: "USD"})
+    iex> event = Timber.Events.CustomEvent.new(type: :payment_rejected, data: %{customer_id: "xiaus1934", amount: 1900, currency: "USD"})
     iex> Logger.info("Payment rejected", event: event)
 
   This adds compile time guarantees in exchange for relying on the Timber library. Please see
@@ -31,7 +31,7 @@ defprotocol Timber.Eventable do
     iex> # ... code to time ...
     iex> time_ms = Timber.Timer.duration_ms(timer)
     iex> event_data = %{customer_id: "xiaus1934", amount: 1900, currency: "USD", time_ms: time_ms}
-    iex> Logger.info("Payment rejected", event: %{name: :payment_rejected, data: event_data})
+    iex> Logger.info("Payment rejected", event: %{type: :payment_rejected, data: event_data})
 
   ## Pro tip! Use your own structs.
 
@@ -43,17 +43,17 @@ defprotocol Timber.Eventable do
 
     iex> defimpl Timber.Eventable, for: Any do
     iex>   def to_event(%{__struct__: module} = event) do
-    iex>     name = module.name()
+    iex>     type = module.type()
     iex>     data = Map.from_struct(event)
-    iex>     Timber.Events.CustomEvent.new(name: name, data: data)
+    iex>     Timber.Events.CustomEvent.new(type: type, data: data)
     iex>   end
     iex> end
 
-  Notice we expect every event to have a `name` function, Timber requires this for custom events.
+  Notice we expect every event to have a `type` function, Timber requires this for custom events.
   Let's define a behaviour to ensure all events follow this pattern:
 
     iex> defmodule MyApp.Event do
-    iex>   @callback name(struct()) :: atom()
+    iex>   @callback type(struct()) :: atom()
     iex> end
 
   Lastly, define your event and log it!:
@@ -63,7 +63,7 @@ defprotocol Timber.Eventable do
     iex>   @behaviour MyApp.Event
     iex>   @derive Timber.Eventable
     iex>   defstruct [:customer_id, :amount, :currency]
-    iex>   def name(_event), do: :payment_rejected
+    iex>   def type(_event), do: :payment_rejected
     iex> end
     iex> event = %PaymentRejectedEvent{customer_id: "xiaus1934", amount: 1900, currency: "USD"}
     iex> Logger.info("Payment rejected", event: event)
@@ -110,9 +110,9 @@ defimpl Timber.Eventable, for: Timber.Events.TemplateRenderEvent do
 end
 
 defimpl Timber.Eventable, for: Map do
-  def to_event(%{name: name, data: data}) do
+  def to_event(%{type: type, data: data}) do
     %Timber.Events.CustomEvent{
-      name: name,
+      type: type,
       data: data
     }
   end

--- a/lib/timber/eventable.ex
+++ b/lib/timber/eventable.ex
@@ -53,7 +53,7 @@ defprotocol Timber.Eventable do
   Let's define a behaviour to ensure all events follow this pattern:
 
     iex> defmodule MyApp.Event do
-    iex>   @callback name() :: atom()
+    iex>   @callback name(struct()) :: atom()
     iex> end
 
   Lastly, define your event and log it!:
@@ -63,7 +63,7 @@ defprotocol Timber.Eventable do
     iex>   @behaviour MyApp.Event
     iex>   @derive Timber.Eventable
     iex>   defstruct [:customer_id, :amount, :currency]
-    iex>   def name(), do: :payment_rejected
+    iex>   def name(_event), do: :payment_rejected
     iex> end
     iex> event = %PaymentRejectedEvent{customer_id: "xiaus1934", amount: 1900, currency: "USD"}
     iex> Logger.info("Payment rejected", event: event)

--- a/lib/timber/events/controller_call_event.ex
+++ b/lib/timber/events/controller_call_event.ex
@@ -3,8 +3,6 @@ defmodule Timber.Events.ControllerCallEvent do
   Represents a controller being called
   """
 
-  @behaviour Timber.Event
-
   @type t :: %__MODULE__{
     action: String.t | nil,
     controller: String.t | nil,

--- a/lib/timber/events/custom_event.ex
+++ b/lib/timber/events/custom_event.ex
@@ -3,60 +3,52 @@ defmodule Timber.Events.CustomEvent do
   Allows for custom events that aren't covered elsewhere.
 
   Custom events can be used to encode information about events that are central
-  to your line of business like receiving credit card payments, adding products
-  to a card, saving a draft of a post, or changing a user's password.
+  to your line of business like receiving credit card payments, saving a draft of a post,
+  or changing a user's password.
 
   ## Fields
 
-    * `name` - This is the name of your event. This can be anything that adheres
+    * `name` - (required) This is the name of your event. This can be anything that adheres
       to the `String.Chars' protocol. It will be used to identify this event on the Timber
       interface. Example: `:my_event` or or `MyEvent`. At Timber we like to reserve CamelCase
       events for actual modules and snake_case events for inline events.
-    * `data` - A map of data. This can be anything that implemented the `Poison.Encoder`
-      protocol. That is, anything that can be JSON encoded. example: `%{key: "value"}`
+    * `data` - (optional) A map of data. This can be anything that implemented the `Poison.Encoder`
+      protocol. That is, anything that can be JSON encoded. example: `%{key: "value"}`.
+
+  ## Special `data` fields
+
+  These are special fields Timber looks for to enhancement your experience with our interface.
+  For example, if `time_ms` is present we'll display it next to the log line.
+
     * `time_ms` - A fractional float represented the execution time in milliseconds.
       example: `45.6`
 
+  An example:
+
+    Timber.Events.CustomEvent.new(name: :payment_rejected, data: %{time_ms: 45.6})
+
   ## Examples
 
-  Please see `Timber.Event` for examples on passing custom event information.
+  Please see `Timber.Eventable` for examples on using custom events.
 
   """
 
-  @behaviour Timber.Event
-
   @type t :: %__MODULE__{
-    name: String.t,
-    data: map() | nil,
-    time_ms: float() | nil,
-    message: String.t
+    name: atom(),
+    data: map() | nil
   }
 
   @enforce_keys [:name]
   defstruct [
     :data,
-    :name,
-    :time_ms,
-    :message
+    :name
   ]
 
   @doc ~S"""
   Creates a new custom event. Takes any of the fields described in the module docs as keys.
-
-  ## Additional options
-
-    * `timer` - The value returned when calling `Timber.Timer.start()`. By passing this
-      `time_ms` will automatically be set for you.
   """
   @spec new(Keyword.t) :: t
   def new(opts) do
     struct(__MODULE__, opts)
   end
-
-  def message(%{message: message}) when is_binary(message),
-    do: message
-  def message(%{name: name, time_ms: time_ms}) when is_float(time_ms),
-    do: "#{name} in #{time_ms}ms"
-  def message(%{name: name}),
-    do: "#{name}"
 end

--- a/lib/timber/events/custom_event.ex
+++ b/lib/timber/events/custom_event.ex
@@ -8,12 +8,11 @@ defmodule Timber.Events.CustomEvent do
 
   ## Fields
 
-    * `name` - (required) This is the name of your event. This can be anything that adheres
-      to the `String.Chars' protocol. It will be used to identify this event on the Timber
-      interface. Example: `:my_event` or or `MyEvent`. At Timber we like to reserve CamelCase
-      events for actual modules and snake_case events for inline events.
-    * `data` - (optional) A map of data. This can be anything that implemented the `Poison.Encoder`
-      protocol. That is, anything that can be JSON encoded. example: `%{key: "value"}`.
+    * `type` - (atom, required) This is the type of your event. It should be something unique
+      and unchanging. It will be used to identify this event. Example: `:my_event`.
+    * `data` - (map, optional) A map of data. This can be anything that implements the
+      `Poison.Encoder` protocol. That is, anything that can be JSON encoded.
+      Example: `%{key: "value"}`.
 
   ## Special `data` fields
 
@@ -25,7 +24,7 @@ defmodule Timber.Events.CustomEvent do
 
   An example:
 
-    Timber.Events.CustomEvent.new(name: :payment_rejected, data: %{time_ms: 45.6})
+    Timber.Events.CustomEvent.new(type: :payment_rejected, data: %{time_ms: 45.6})
 
   ## Examples
 
@@ -34,14 +33,14 @@ defmodule Timber.Events.CustomEvent do
   """
 
   @type t :: %__MODULE__{
-    name: atom(),
+    type: atom(),
     data: map() | nil
   }
 
-  @enforce_keys [:name]
+  @enforce_keys [:type]
   defstruct [
     :data,
-    :name
+    :type
   ]
 
   @doc ~S"""

--- a/lib/timber/events/custom_event.ex
+++ b/lib/timber/events/custom_event.ex
@@ -16,8 +16,7 @@ defmodule Timber.Events.CustomEvent do
 
   ## Special `data` fields
 
-  These are special fields Timber looks for to enhancement your experience with our interface.
-  For example, if `time_ms` is present we'll display it next to the log line.
+  These are special fields Timber looks for to enhancement your experience with our interface:
 
     * `time_ms` - A fractional float represented the execution time in milliseconds.
       example: `45.6`

--- a/lib/timber/events/exception_event.ex
+++ b/lib/timber/events/exception_event.ex
@@ -10,8 +10,6 @@ defmodule Timber.Events.ExceptionEvent do
 
   alias Timber.Utils
 
-  @behaviour Timber.Event
-
   @type stacktrace_entry :: {
     module,
     atom,
@@ -47,8 +45,8 @@ defmodule Timber.Events.ExceptionEvent do
   end
 
   @spec message(t) :: IO.chardata
-  def message(%__MODULE__{message: message}),
-    do: message
+  def message(%__MODULE__{name: name, message: message}),
+    do: "#{name}: #{message}"
 
   defp transform_error(error) when is_atom(error) do
     name = inspect(error)

--- a/lib/timber/events/exception_event.ex
+++ b/lib/timber/events/exception_event.ex
@@ -27,20 +27,18 @@ defmodule Timber.Events.ExceptionEvent do
     backtrace: [backtrace_entry] | [],
     name: String.t,
     message: String.t,
-    data: map() | nil
   }
 
   defstruct [:backtrace, :name, :message, :data]
 
   @spec new(atom | Exception.t, [stacktrace_entry] | []) :: t
   def new(error, stacktrace \\ []) do
-    {name, message, data} = transform_error(error)
+    {name, message} = transform_error(error)
     backtrace = Enum.map(stacktrace, &transform_stacktrace/1)
     %__MODULE__{
       name: name,
       message: message,
-      backtrace: backtrace,
-      data: data
+      backtrace: backtrace
     }
   end
 
@@ -50,17 +48,13 @@ defmodule Timber.Events.ExceptionEvent do
 
   defp transform_error(error) when is_atom(error) do
     name = inspect(error)
-    {name, name, nil}
+    {name, name}
   end
 
   defp transform_error(%{__exception__: true, __struct__: module} = error) do
     name = Utils.module_name(module)
     msg = Exception.message(error)
-    data =
-      error
-      |> Map.from_struct()
-      |> Map.delete(:message)
-    {name, msg, data}
+    {name, msg}
   end
 
   defp transform_stacktrace({module, function_name, arity, fileinfo}) do

--- a/lib/timber/events/exception_event.ex
+++ b/lib/timber/events/exception_event.ex
@@ -29,7 +29,7 @@ defmodule Timber.Events.ExceptionEvent do
     message: String.t,
   }
 
-  defstruct [:backtrace, :name, :message, :data]
+  defstruct [:backtrace, :name, :message]
 
   @spec new(atom | Exception.t, [stacktrace_entry] | []) :: t
   def new(error, stacktrace \\ []) do

--- a/lib/timber/events/http_request_event.ex
+++ b/lib/timber/events/http_request_event.ex
@@ -6,8 +6,6 @@ defmodule Timber.Events.HTTPRequestEvent do
   you use a `Plug` based framework through the `Timber.Plug`.
   """
 
-  @behaviour Timber.Event
-
   @type t :: %__MODULE__{
     host: String.t | nil,
     headers: headers | nil,

--- a/lib/timber/events/http_response_event.ex
+++ b/lib/timber/events/http_response_event.ex
@@ -6,8 +6,6 @@ defmodule Timber.Events.HTTPResponseEvent do
   use a `Plug` based framework through `Timber.Plug`.
   """
 
-  @behaviour Timber.Event
-
   @type t :: %__MODULE__{
     bytes: non_neg_integer,
     headers: headers,

--- a/lib/timber/events/sql_query_event.ex
+++ b/lib/timber/events/sql_query_event.ex
@@ -3,8 +3,6 @@ defmodule Timber.Events.SQLQueryEvent do
   The SQL Query event tracks SQL query performance
   """
 
-  @behaviour Timber.Event
-
   @type t :: %__MODULE__{
     sql: String.t,
     time_ms: float

--- a/lib/timber/events/template_render_event.ex
+++ b/lib/timber/events/template_render_event.ex
@@ -3,8 +3,6 @@ defmodule Timber.Events.TemplateRenderEvent do
   Tracks the time to render a template
   """
 
-  @behaviour Timber.Event
-
   @type t :: %__MODULE__{
     name: String.t | nil,
     time_ms: float | nil,

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -49,7 +49,7 @@ defmodule Timber.LogEntry do
       |> IO.chardata_to_string()
 
     context = Keyword.get(metadata, :timber_context, %{})
-    event = case Keyword.get(metadata, :timber_event, nil) do
+    event = case Keyword.get(metadata, Timber.Config.event_key(), nil) do
       nil -> nil
       data -> Eventable.to_event(data)
     end

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -101,7 +101,7 @@ defmodule Timber.LogEntry do
 
   defp to_api_map(%Events.ControllerCallEvent{} = event),
     do: %{controller_call: Map.from_struct(event)}
-  defp to_api_map(%Events.CustomEvent{name: name, data: data} = event),
+  defp to_api_map(%Events.CustomEvent{type: type, data: data}),
     do: %{custom: %{type => data}}
   defp to_api_map(%Events.ExceptionEvent{} = event),
     do: %{exception: Map.from_struct(event)}

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -100,19 +100,19 @@ defmodule Timber.LogEntry do
   end
 
   defp to_api_map(%Events.ControllerCallEvent{} = event),
-    do: %{type: :controller_call, data: Map.from_struct(event)}
+    do: %{controller_call: Map.from_struct(event)}
   defp to_api_map(%Events.CustomEvent{name: name, data: data} = event),
-    do: %{type: :custom, name: name, data: data}
+    do: %{custom: %{type => data}}
   defp to_api_map(%Events.ExceptionEvent{} = event),
-    do: %{type: :exception, data: Map.from_struct(event)}
+    do: %{exception: Map.from_struct(event)}
   defp to_api_map(%Events.HTTPRequestEvent{} = event),
-    do: %{type: :http_request, data: Map.from_struct(event)}
+    do: %{http_request: Map.from_struct(event)}
   defp to_api_map(%Events.HTTPResponseEvent{} = event),
-    do: %{type: :http_response, data: Map.from_struct(event)}
+    do: %{http_response: Map.from_struct(event)}
   defp to_api_map(%Events.SQLQueryEvent{} = event),
-    do: %{type: :sql_query, data: Map.from_struct(event)}
+    do: %{sql_query: Map.from_struct(event)}
   defp to_api_map(%Events.TemplateRenderEvent{} = event),
-    do: %{type: :template_render, data: Map.from_struct(event)}
+    do: %{template_render: Map.from_struct(event)}
 
   @spec encode!(format, map) :: IO.chardata
   defp encode!(:json, value) do

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -16,6 +16,7 @@ defmodule Timber.LogEntry do
 
   alias Timber.Context
   alias Timber.Logger
+  alias Timber.Event
   alias Timber.Eventable
   alias Timber.Events
   alias Timber.Utils
@@ -71,42 +72,32 @@ defmodule Timber.LogEntry do
   """
   @spec to_string!(t, format, Keyword.t) :: IO.chardata
   def to_string!(log_entry, format, options) do
-    # Convert to a map for encoding.
-    map = Map.from_struct(log_entry)
+    map = to_map!(log_entry, options)
+    encode!(format, map)
+  end
 
-    # Key the event in a form that the Timber API expects.
+  @spec to_map!(t, Keyword.t) :: map()
+  defp to_map!(log_entry, options) do
     map =
-      case Map.get(map, :event, nil) do
-        nil -> map
-        event ->
-          event_map =
-            event
-            |> Map.from_struct()
-            |> Utils.drop_nil_values()
-          keyed_event = %{key_for_event(event) => event_map}
-          Map.put(map, :event, keyed_event)
-      end
+      log_entry
+      |> Map.from_struct()
+      |> Map.get_and_update(:event, fn current_event ->
+        if current_event == nil do
+          {current_event, current_event}
+        else
+          {current_event, Event.to_api_map(current_event)}
+        end
+      end)
 
     only = Keyword.get(options, :only, false)
 
-    value_to_encode =
-      if only do
-        Map.take(map, only)
-      else
-        map
-      end
-      |> Utils.drop_nil_values()
-
-    encode!(format, value_to_encode)
+    if only do
+      Map.take(map, only)
+    else
+      map
+    end
+    |> Utils.drop_nil_values()
   end
-
-  defp key_for_event(%Events.ControllerCallEvent{}), do: :controller_call
-  defp key_for_event(%Events.CustomEvent{}), do: :custom
-  defp key_for_event(%Events.ExceptionEvent{}), do: :exception
-  defp key_for_event(%Events.HTTPRequestEvent{}), do: :http_request
-  defp key_for_event(%Events.HTTPResponseEvent{}), do: :http_response
-  defp key_for_event(%Events.SQLQueryEvent{}), do: :sql_query
-  defp key_for_event(%Events.TemplateRenderEvent{}), do: :template_render
 
   @spec encode!(format, map) :: IO.chardata
   defp encode!(:json, value) do

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -85,7 +85,7 @@ defmodule Timber.LogEntry do
         if current_event == nil do
           {current_event, current_event}
         else
-          {current_event, Event.to_api_map(current_event)}
+          {current_event, to_api_map(current_event)}
         end
       end)
 
@@ -98,6 +98,21 @@ defmodule Timber.LogEntry do
     end
     |> Utils.drop_nil_values()
   end
+
+  defp to_api_map(%Events.ControllerCallEvent{} = event),
+    do: %{type: :controller_call, data: Map.from_struct(event)}
+  defp to_api_map(%Events.CustomEvent{name: name, data: data} = event),
+    do: %{type: :custom, name: name, data: data}
+  defp to_api_map(%Events.ExceptionEvent{} = event),
+    do: %{type: :exception, data: Map.from_struct(event)}
+  defp to_api_map(%Events.HTTPRequestEvent{} = event),
+    do: %{type: :http_request, data: Map.from_struct(event)}
+  defp to_api_map(%Events.HTTPResponseEvent{} = event),
+    do: %{type: :http_response, data: Map.from_struct(event)}
+  defp to_api_map(%Events.SQLQueryEvent{} = event),
+    do: %{type: :sql_query, data: Map.from_struct(event)}
+  defp to_api_map(%Events.TemplateRenderEvent{} = event),
+    do: %{type: :template_render, data: Map.from_struct(event)}
 
   @spec encode!(format, map) :: IO.chardata
   defp encode!(:json, value) do

--- a/lib/timber/logger.ex
+++ b/lib/timber/logger.ex
@@ -29,7 +29,7 @@ defmodule Timber.Logger do
   the configuration.
 
   ### transport_state
-  
+
   The transport state. This is initialized by calling `init/1` on the
   transport with transport configuration data from the application
   config.
@@ -205,6 +205,6 @@ defmodule Timber.Logger do
   # configuration
   @spec get_transport() :: module
   defp get_transport() do
-    Application.get_env(:timber, :transport)
+    Timber.Config.transport()
   end
 end

--- a/lib/timber/phoenix_instrumenter.ex
+++ b/lib/timber/phoenix_instrumenter.ex
@@ -93,7 +93,10 @@ defmodule Timber.PhoenixInstrumenter do
       controller: controller
     )
 
-    Logger.log(log_level, ControllerCallEvent.message(event), timber_event: event)
+    message = ControllerCallEvent.message(event)
+    metadata = Timber.Event.metadata(event)
+
+    Logger.log(log_level, message, metadata)
 
     :ok
   end
@@ -109,7 +112,7 @@ defmodule Timber.PhoenixInstrumenter do
   end
 
   def phoenix_controller_render(:stop, time_diff, {:ok, template_name}) do
-    log_level = get_log_level(:info)
+    log_level = Timber.Config.phoenix_instrumentation_level(:info)
 
     # This comes in as native time but is expected to be a float representing
     # milliseconds
@@ -123,13 +126,11 @@ defmodule Timber.PhoenixInstrumenter do
       time_ms: time_ms
     )
 
-    Logger.log(log_level, TemplateRenderEvent.message(event), timber_event: event)
+    message = TemplateRenderEvent.message(event)
+    metadata = Timber.Event.metadata(event)
+
+    Logger.log(log_level, message, metadata)
 
     :ok
-  end
-
-  @spec get_log_level(atom) :: atom
-  defp get_log_level(default) do
-    Application.get_env(:timber, :instrumentation_level, default)
   end
 end

--- a/lib/timber/phoenix_instrumenter.ex
+++ b/lib/timber/phoenix_instrumenter.ex
@@ -112,7 +112,7 @@ defmodule Timber.PhoenixInstrumenter do
   end
 
   def phoenix_controller_render(:stop, time_diff, {:ok, template_name}) do
-    log_level = Timber.Config.phoenix_instrumentation_level(:info)
+    log_level = get_log_level(:info)
 
     # This comes in as native time but is expected to be a float representing
     # milliseconds
@@ -132,5 +132,10 @@ defmodule Timber.PhoenixInstrumenter do
     Logger.log(log_level, message, metadata)
 
     :ok
+  end
+
+  @spec get_log_level(atom) :: atom
+  defp get_log_level(default) do
+    Timber.Config.phoenix_instrumentation_level(default)
   end
 end

--- a/lib/timber/transports/io_device.ex
+++ b/lib/timber/transports/io_device.ex
@@ -25,12 +25,12 @@ defmodule Timber.Transports.IODevice do
   until the IO device sends a response about the last write operation.
 
   ## Configuration Recommendations: Development vs. Production
-  
+
   In a standard Elixir project, you will probably have different configuration files
   for your development and production setups. These configuration files typically
   take the form of `config/dev.exs` and `config/prod.exs` which override defaults set
   in `config/config.exs`.
-  
+
   Timber's defaults are production ready, but the production settings also assume that
   you'll be viewing the logs through the Timber console, so they forego some niceties
   that help when developing locally. Therefore, to help with local development, we
@@ -63,7 +63,7 @@ defmodule Timber.Transports.IODevice do
   _Defaults to `true`._
 
   #### `escape_new_lines`
-  
+
   When `true`, new lines characters are escaped as `\\n`.
 
   When `false`, new lines characters are left alone.
@@ -77,7 +77,7 @@ defmodule Timber.Transports.IODevice do
   configuration will always override the initialized setting..
 
   #### `format`
-  
+
   Determines the output format to use. Even though the Timber service is designed
   to receive log metadata in JSON format, it's not the prettiest format to look at when
   you're developing locally. Therefore, we let you print the metadata in logfmt locally
@@ -100,7 +100,7 @@ defmodule Timber.Transports.IODevice do
   _Defaults to `100`._
 
   #### `print_log_level`
-  
+
   When `true`, the log level is printed in brackets as part of your log message.
 
   When `false`, the log level is not printed.
@@ -200,10 +200,10 @@ defmodule Timber.Transports.IODevice do
   defp get_init_config() do
     heroku_env = System.get_env("HEROKU")
     heroku? = !is_nil(heroku_env)
-    
+
     init_env = [escape_new_lines: heroku?]
 
-    env = Application.get_env(:timber, :io_device, [])
+    env = Timber.Config.io_device()
 
     Keyword.merge(init_env, env)
   end

--- a/lib/timber/utils.ex
+++ b/lib/timber/utils.ex
@@ -55,7 +55,6 @@ defmodule Timber.Utils do
     time = format_time(time)
     [date | [?T | [time | [?Z]]]]
   end
-
   # Formatting a timestamp with microseconds
   def format_timestamp({date, {_, _, _, {microseconds, _precision}} = time}) do
     date = format_date(date)
@@ -63,7 +62,6 @@ defmodule Timber.Utils do
     partial_seconds = pad6(microseconds)
     [date | [?T | [time | [?. | [partial_seconds | [?Z]]]]]]
   end
-
   # Formatting a timestamp with milliseconds
   def format_timestamp({date, {_, _, _, milliseconds} = time}) do
     date = format_date(date)


### PR DESCRIPTION
This removes the advanced custom event usage supporting custom events as your own defined structs. Instead, we provide an example of how to easily implement this in your app. 