### PR TITLE
Add runtime context

### DIFF
--- a/lib/timber/context.ex
+++ b/lib/timber/context.ex
@@ -63,6 +63,7 @@ defmodule Timber.Context do
   defp type(%Contexts.HTTPContext{}), do: :http
   defp type(%Contexts.OrganizationContext{}), do: :organization
   defp type(%Contexts.ProcessContext{}), do: :process
+  defp type(%Contexts.RuntimeContext{}), do: :runtime
   defp type(%Contexts.ServerContext{}), do: :server
   defp type(%Contexts.UserContext{}), do: :user
 end

--- a/lib/timber/contexts/runtime_context.ex
+++ b/lib/timber/contexts/runtime_context.ex
@@ -8,7 +8,7 @@ defmodule Timber.Contexts.RuntimeContext do
     file: String.t,
     function: String.t,
     line: String.t,
-    module: String.t,
+    module_name: String.t,
     vm_pid: String.t
   }
 
@@ -17,9 +17,9 @@ defmodule Timber.Contexts.RuntimeContext do
     file: String.t,
     function: String.t,
     line: String.t,
-    module: String.t,
+    module_name: String.t,
     vm_pid: String.t
   }
 
-  defstruct [:application, :file, :function, :line, :module, :vm_pid]
+  defstruct [:application, :file, :function, :line, :module_name, :vm_pid]
 end

--- a/lib/timber/contexts/runtime_context.ex
+++ b/lib/timber/contexts/runtime_context.ex
@@ -1,0 +1,25 @@
+defmodule Timber.Contexts.RuntimeContext do
+  @moduledoc """
+  The Server context tracks information about the host your system runs on
+  """
+
+  @type t :: %__MODULE__{
+    application: String.t,
+    file: String.t,
+    function: String.t,
+    line: String.t,
+    module: String.t,
+    vm_pid: String.t
+  }
+
+  @type m :: %{
+    application: String.t,
+    file: String.t,
+    function: String.t,
+    line: String.t,
+    module: String.t,
+    vm_pid: String.t
+  }
+
+  defstruct [:application, :file, :function, :line, :module, :vm_pid]
+end

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -17,22 +17,6 @@ defmodule Timber.Event do
     Events.TemplateRenderEvent
 
   @doc """
-  Convenience function for using the metadata logger key specified in the configuration.
-  This is equivalent to:
-
-  ## Examples
-
-  ```elixir
-  metadata = Timber.Event.to_logger_metadata(event)
-  Logger.info("my message", metadata)
-  ```
-  """
-  @spec to_logger_metadata(t) :: Keyword.t
-  def to_logger_metadata(event) do
-    Keyword.put([], Timber.Config.event_key(), event)
-  end
-
-  @doc """
   Returns the official Timber type for this event. Used as the JSON map key when
   sending to Timber.
   """

--- a/lib/timber/integrations/ecto_logger.ex
+++ b/lib/timber/integrations/ecto_logger.ex
@@ -79,7 +79,7 @@ defmodule Timber.Integrations.EctoLogger do
     }
 
     message = SQLQueryEvent.message(event)
-    metadata = Timber.Event.to_logger_metadata(event)
+    metadata = Timber.Utils.Logger.event_to_metadata(event)
 
     Logger.log(level, message, metadata)
 

--- a/lib/timber/integrations/error_logger.ex
+++ b/lib/timber/integrations/error_logger.ex
@@ -90,7 +90,7 @@ defmodule Timber.Integrations.ErrorLogger do
         message = ExceptionEvent.message(event)
         metadata =
           event
-          |> Timber.Event.to_logger_metadata()
+          |> Timber.Utils.Logger.event_to_metadata()
           |> Keyword.put(:timber_context, context)
 
         Logger.error(message, metadata)
@@ -106,7 +106,7 @@ defmodule Timber.Integrations.ErrorLogger do
     event = ExceptionEvent.new(error, stacktrace)
 
     message = ExceptionEvent.message(event)
-    metadata = Timber.Event.to_logger_metadata(event)
+    metadata = Timber.Utils.Logger.event_to_metadata(event)
 
     Logger.error(message, metadata)
 

--- a/lib/timber/integrations/event_plug.ex
+++ b/lib/timber/integrations/event_plug.ex
@@ -68,7 +68,6 @@ defmodule Timber.Integrations.EventPlug do
 
   require Logger
 
-  alias Timber.Event
   alias Timber.Events.{HTTPServerRequestEvent, HTTPServerResponseEvent}
   alias Timber.Utils.Plug, as: PlugUtils
 
@@ -117,7 +116,7 @@ defmodule Timber.Integrations.EventPlug do
     )
 
     message = HTTPServerRequestEvent.message(event)
-    metadata = Event.to_logger_metadata(event)
+    metadata = Timber.Utils.Logger.event_to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 
@@ -149,7 +148,7 @@ defmodule Timber.Integrations.EventPlug do
     )
 
     message = HTTPServerResponseEvent.message(event)
-    metadata = Event.to_logger_metadata(event)
+    metadata = Timber.Utils.Logger.event_to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -94,7 +94,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     }
 
     message = ControllerCallEvent.message(event)
-    metadata = Timber.Event.to_logger_metadata(event)
+    metadata = Timber.Utils.Logger.event_to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 
@@ -127,7 +127,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     }
 
     message = TemplateRenderEvent.message(event)
-    metadata = Timber.Event.to_logger_metadata(event)
+    metadata = Timber.Utils.Logger.event_to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -21,6 +21,7 @@ defmodule Timber.LogEntry do
   alias Timber.Eventable
   alias Timber.Events.CustomEvent
   alias Timber.Utils.Logger, as: UtilsLogger
+  alias Timber.Utils.Module, as: UtilsModule
   alias Timber.Utils.Timestamp, as: UtilsTimestamp
   alias Timber.Utils.Map, as: UtilsMap
   alias Timber.LogfmtEncoder
@@ -76,12 +77,17 @@ defmodule Timber.LogEntry do
   # Add the default Elixir Logger runtime metadata as runtime context.
   defp add_runtime_context(context, metadata) do
     application = Keyword.get(metadata, :application)
-    module = Keyword.get(metadata, :module)
+    module_name = Keyword.get(metadata, :module)
+    module_name = if module_name do
+      UtilsModule.name(module_name)
+    else
+      module_name
+    end
     fun = Keyword.get(metadata, :function)
     file = Keyword.get(metadata, :file)
     line = Keyword.get(metadata, :line)
-    runtime_context = %RuntimeContext{application: application, module: module, function: fun,
-      file: file,line: line}
+    runtime_context = %RuntimeContext{application: application, module_name: module_name,
+      function: fun, file: file,line: line}
     Context.add_context(context, runtime_context)
   end
 

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -15,10 +15,12 @@ defmodule Timber.LogEntry do
   """
 
   alias Timber.Context
+  alias Timber.Contexts.RuntimeContext
   alias Timber.LoggerBackend
   alias Timber.Event
   alias Timber.Eventable
-  alias Timber.Events
+  alias Timber.Events.CustomEvent
+  alias Timber.Utils.Logger, as: UtilsLogger
   alias Timber.Utils.Timestamp, as: UtilsTimestamp
   alias Timber.Utils.Map, as: UtilsMap
   alias Timber.LogfmtEncoder
@@ -48,11 +50,16 @@ defmodule Timber.LogEntry do
   @spec new(LoggerBackend.timestamp, Logger.level, Logger.message, Keyword.t) :: t
   def new(timestamp, level, message, metadata) do
     io_timestamp =
-      UtilsTimestamp.format_timestamp(timestamp)
+      timestamp
+      |> UtilsTimestamp.format_timestamp()
       |> IO.chardata_to_string()
 
-    context = Keyword.get(metadata, :timber_context, %{})
-    event = case Keyword.get(metadata, Timber.Config.event_key(), nil) do
+    context =
+      metadata
+      |> Keyword.get(:timber_context, %{})
+      |> add_runtime_context(metadata)
+
+    event = case UtilsLogger.get_event_from_metadata(metadata) do
       nil -> nil
       data -> Eventable.to_event(data)
     end
@@ -64,6 +71,18 @@ defmodule Timber.LogEntry do
       message: message,
       context: context
     }
+  end
+
+  # Add the default Elixir Logger runtime metadata as runtime context.
+  defp add_runtime_context(context, metadata) do
+    application = Keyword.get(metadata, :application)
+    module = Keyword.get(metadata, :module)
+    fun = Keyword.get(metadata, :function)
+    file = Keyword.get(metadata, :file)
+    line = Keyword.get(metadata, :line)
+    runtime_context = %RuntimeContext{application: application, module: module, function: fun,
+      file: file,line: line}
+    Context.add_context(context, runtime_context)
   end
 
   @doc """
@@ -104,7 +123,7 @@ defmodule Timber.LogEntry do
     |> UtilsMap.recursively_drop_blanks()
   end
 
-  defp to_api_map(%Events.CustomEvent{type: type, data: data}),
+  defp to_api_map(%CustomEvent{type: type, data: data}),
     do: %{server_side_app: %{custom: %{type => data}}}
   defp to_api_map(event) do
     type = Event.type(event)

--- a/lib/timber/logger_backend.ex
+++ b/lib/timber/logger_backend.ex
@@ -12,7 +12,6 @@ defmodule Timber.LoggerBackend do
   """
   use GenEvent
 
-  alias Timber.Contexts.RuntimeContext
   alias Timber.LogEntry
   alias Timber.Transport
 
@@ -180,13 +179,6 @@ defmodule Timber.LoggerBackend do
   @spec output_event(timestamp, level, IO.chardata, Keyword.t, t) :: t
   defp output_event(ts, level, message, metadata, state) do
     %{transport: transport, transport_state: transport_state} = state
-
-    module = Keyword.get(metadata, :module)
-    fun = Keyword.get(metadata, :function)
-    file = Keyword.get(metadata, :file)
-    line = Keyword.get(metadata, :file)
-    %RuntimeContext{module: module, function: fun, file: file, line: line}
-    |> Timber.add_context()
 
     log_entry = LogEntry.new(ts, level, message, metadata)
 

--- a/lib/timber/logger_backend.ex
+++ b/lib/timber/logger_backend.ex
@@ -11,6 +11,8 @@ defmodule Timber.LoggerBackend do
   asynchronous or synchronous.
   """
   use GenEvent
+
+  alias Timber.Contexts.RuntimeContext
   alias Timber.LogEntry
   alias Timber.Transport
 
@@ -178,6 +180,13 @@ defmodule Timber.LoggerBackend do
   @spec output_event(timestamp, level, IO.chardata, Keyword.t, t) :: t
   defp output_event(ts, level, message, metadata, state) do
     %{transport: transport, transport_state: transport_state} = state
+
+    module = Keyword.get(metadata, :module)
+    fun = Keyword.get(metadata, :function)
+    file = Keyword.get(metadata, :file)
+    line = Keyword.get(metadata, :file)
+    %RuntimeContext{module: module, function: fun, file: file, line: line}
+    |> Timber.add_context()
 
     log_entry = LogEntry.new(ts, level, message, metadata)
 

--- a/lib/timber/utils/logger.ex
+++ b/lib/timber/utils/logger.ex
@@ -1,0 +1,22 @@
+defmodule Timber.Utils.Logger do
+  @doc """
+  Convenience function for using the metadata logger key specified in the configuration.
+  This is equivalent to:
+
+  ## Examples
+
+  ```elixir
+  metadata = Timber.Utils.Logger.event_to_metadata(event)
+  Logger.info("my message", metadata)
+  ```
+  """
+  @spec event_to_metadata(Timber.Event.t) :: Keyword.t
+  def event_to_metadata(event) do
+    Keyword.put([], Timber.Config.event_key(), event)
+  end
+
+  @spec get_event_from_metadata(Keyword.t) :: nil | Timber.Event.t
+  def get_event_from_metadata(metadata) do
+    Keyword.get(metadata, Timber.Config.event_key(), nil)
+  end
+end


### PR DESCRIPTION
Adds the runtime context to capture default `Logger` metadata.