### PR TITLE
Fix transport default for IODevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ config :logger,
   backends: [Timber.LoggerBackend],
   handle_otp_reports: false # Timber handles errors, structures them, and adds additional metadata
 
-# Because the logger is no longer handling errors we instruct Timber to do so
 config :timber, :capture_errors, true
 ```
 

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -26,5 +26,5 @@ defmodule Timber.Config do
   `Timber.Transports.IODevice`.
   """
   def transport,
-    do: Application.get_env(@env_key, :transport)
+    do: Application.get_env(@env_key, :transport, Timber.Transports.IODevice)
 end

--- a/lib/timber/transports/io_device.ex
+++ b/lib/timber/transports/io_device.ex
@@ -184,7 +184,7 @@ defmodule Timber.Transports.IODevice do
             buffer: []
 
   @doc false
-  @spec init() :: {:ok, t}
+  @spec init() :: {:ok, t} | {:error, Exception.t}
   def init() do
     init_config = get_init_config()
     filename = Keyword.get(init_config, :file, :no_file)


### PR DESCRIPTION
It appears Timber is not using `IODevice` as the transport default. When specifying the `IODevice` directly our example app starts just fine:

```
config :timber,
  transport: Timber.Transports.IODevice,
  capture_errors: true
```

If we remove the `transport` line I get the following error:

```
~/C/t/elixir_phoenix_example_app ❯❯❯ mix phoenix.server                                                                                                                       install-timber ✱
==> timber
Compiling 42 files (.ex)
warning: function :hackney.request/5 is undefined (module :hackney is not available)
  lib/timber/transports/http/hackney_client.ex:62

warning: function :hackney_pool.child_spec/2 is undefined (module :hackney_pool is not available)
  lib/timber.ex:66

Generated timber app
==> elixir_phoenix_example_app
Compiling 12 files (.ex)
Generated elixir_phoenix_example_app app

=INFO REPORT==== 12-Feb-2017::19:14:39 ===
    application: logger
    exited: {{shutdown,
              {failed_to_start_child,'Elixir.Logger.Watcher',
               {'EXIT',
                {{badmatch,
                  {error,
                   {{{case_clause,
                      {'EXIT',
                       {undef,
                        [{nil,init,[],[]},
                         {'Elixir.Timber.LoggerBackend',init,1,
                          [{file,"lib/timber/logger_backend.ex"},{line,89}]},
                         {gen_event,server_add_handler,4,
                          [{file,"gen_event.erl"},{line,429}]},
                         {gen_event,handle_msg,5,
                          [{file,"gen_event.erl"},{line,274}]},
                         {proc_lib,init_p_do_apply,3,
                          [{file,"proc_lib.erl"},{line,247}]}]}}},
                     [{'Elixir.Logger.Watcher',do_init,3,
                       [{file,"lib/logger/watcher.ex"},{line,78}]},
                      {gen_server,init_it,6,
                       [{file,"gen_server.erl"},{line,328}]},
                      {proc_lib,init_p_do_apply,3,
                       [{file,"proc_lib.erl"},{line,247}]}]},
                    {child,undefined,
                     {'Elixir.Logger.Watcher',
                      {'Elixir.Logger','Elixir.Timber.LoggerBackend'}},
                     {'Elixir.Logger.Watcher',watcher,
                      ['Elixir.Logger','Elixir.Timber.LoggerBackend',
                       'Elixir.Timber.LoggerBackend']},
                     transient,5000,worker,
                     ['Elixir.Logger.Watcher']}}}},
                 [{'Elixir.Logger.Watcher','-start_link/3-fun-0-',2,
                   [{file,"lib/logger/watcher.ex"},{line,16}]},
                  {'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,
                   [{file,"lib/enum.ex"},{line,1755}]},
                  {'Elixir.Logger.Watcher',start_link,3,
                   [{file,"lib/logger/watcher.ex"},{line,15}]},
                  {supervisor,do_start_child,2,
                   [{file,"supervisor.erl"},{line,365}]},
                  {supervisor,start_children,3,
                   [{file,"supervisor.erl"},{line,348}]},
                  {supervisor,init_children,2,
                   [{file,"supervisor.erl"},{line,314}]},
                  {gen_server,init_it,6,[{file,"gen_server.erl"},{line,328}]},
                  {proc_lib,init_p_do_apply,3,
                   [{file,"proc_lib.erl"},{line,247}]}]}}}},
             {'Elixir.Logger.App',start,[normal,[]]}}
    type: temporary
** (Mix) Could not start application logger: Logger.App.start(:normal, []) returned an error: shutdown: failed to start child: Logger.Watcher
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {{{:case_clause, {:EXIT, {:undef, [{nil, :init, [], []}, {Timber.LoggerBackend, :init, 1, [file: 'lib/timber/logger_backend.ex', line: 89]}, {:gen_event, :server_add_handler, 4, [file: 'gen_event.erl', line: 429]}, {:gen_event, :handle_msg, 5, [file: 'gen_event.erl', line: 274]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}}}, [{Logger.Watcher, :do_init, 3, [file: 'lib/logger/watcher.ex', line: 78]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 328]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}, {:child, :undefined, {Logger.Watcher, {Logger, Timber.LoggerBackend}}, {Logger.Watcher, :watcher, [Logger, Timber.LoggerBackend, Timber.LoggerBackend]}, :transient, 5000, :worker, [Logger.Watcher]}}}
            (logger) lib/logger/watcher.ex:16: anonymous fn/2 in Logger.Watcher.start_link/3
            (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
            (logger) lib/logger/watcher.ex:15: Logger.Watcher.start_link/3
            (stdlib) supervisor.erl:365: :supervisor.do_start_child/2
            (stdlib) supervisor.erl:348: :supervisor.start_children/3
            (stdlib) supervisor.erl:314: :supervisor.init_children/2
            (stdlib) gen_server.erl:328: :gen_server.init_it/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```