### PR TITLE
Delegate start to the specified HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,10 @@ throughput and little overhead. If you'd like to use another client see
   config :timber,
     transport: Timber.Transports.Network,
     api_key: System.get_env("TIMBER_LOGS_KEY")
+
+  config :timber, :http_transport,
+    http_client: Timber.Transports.HTTP.HackneyClient,
+    api_key: System.get_env("TIMBER_LOGS_KEY")
   ```
 
 3. Obtain your Timber API :key: by **[adding your app in Timber](https://app.timber.io)**.

--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ config :timber, :io_device,
   colorize: true,
   format: :logfmt,
   print_timestamps: true,
-  print_log_level: true
+  print_log_level: true,
+  print_metadata: false
 ```
 
 </p></details>

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -57,22 +57,11 @@ defmodule Timber do
       :error_logger.tty(false)
     end
 
-    children =
-      if Timber.Config.transport() == Timber.Transports.HTTP &&
-        Timber.Transports.HTTP.get_http_client() == Timber.Transports.HTTP.HackneyClient
-      do
-        case Code.ensure_loaded(:hackney_pool) do
-          {:module, _mod} ->
-            [:hackney_pool.child_spec(
-              Timber.Transports.HTTP.HackneyClient.get_pool_name(),
-              Timber.Transports.HTTP.HackneyClient.get_pool_options()
-            )]
-          {:error, _error} -> []
-        end
-      else
-        []
-      end
+    if Timber.Transports.HTTP.get_http_client() do
+      Timber.Transports.HTTP.get_http_client().start()
+    end
 
+    children = []
     opts = [strategy: :one_for_one, name: Timber.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -59,9 +59,10 @@ defmodule Timber do
       :error_logger.tty(false)
     end
 
+    http_client = Timber.Transports.HTTP.get_http_client()
     children =
-      if Timber.Transports.HTTP.get_http_client() do
-        [worker(Timber.Transports.HTTP.get_http_client(), [])]
+      if http_client do
+        [worker(http_client, [])]
       else
         []
       end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -182,5 +182,6 @@ defmodule Timber.Transports.HTTP do
   @doc false
   def get_http_client!, do: Keyword.fetch!(config(), :http_client)
 
+  @doc false
   def get_http_client, do: Keyword.get(config(), :http_client)
 end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -42,7 +42,6 @@ defmodule Timber.Transports.HTTP do
   @content_type "application/msgpack"
   @default_max_buffer_size 5000 # 5000 log line should be well below 5mb
   @default_flush_interval 1000
-  @default_http_client __MODULE__.HackneyClient
   @url "https://logs.timber.io/frames"
 
   defstruct api_key: nil,
@@ -142,7 +141,7 @@ defmodule Timber.Transports.HTTP do
       message ->
         # Defer message detection to the client. Each client will have different
         # messages and the check should be contained in there.
-        if get_http_client().done?(ref, message) do
+        if get_http_client!().done?(ref, message) do
           %{state | ref: nil}
         else
           wait_on_request(state)
@@ -173,7 +172,7 @@ defmodule Timber.Transports.HTTP do
       "User-Agent" => user_agent
     }
 
-    {:ok, ref} = get_http_client().async_request(:post, @url, headers, body)
+    {:ok, ref} = get_http_client!().async_request(:post, @url, headers, body)
 
     %{state | ref: ref, buffer: [], buffer_size: 0}
   end
@@ -181,5 +180,7 @@ defmodule Timber.Transports.HTTP do
   defp config, do: Application.get_env(:timber, :http_transport, [])
 
   @doc false
-  def get_http_client, do: Keyword.get(config(), :http_client, @default_http_client)
+  def get_http_client!, do: Keyword.fetch!(config(), :http_client)
+
+  def get_http_client, do: Keyword.get(config(), :http_client)
 end

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -33,6 +33,7 @@ defmodule Timber.Transports.HTTP.Client do
   @type url :: String.t
   @type result :: {:ok, reference} | {:error, atom}
 
+  @callback start :: any
   @callback async_request(method, url, headers, body) :: result
   @callback done?(reference, any) :: boolean
 end

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -33,7 +33,7 @@ defmodule Timber.Transports.HTTP.Client do
   @type url :: String.t
   @type result :: {:ok, reference} | {:error, atom}
 
-  @callback start :: any
+  @callback start_link :: {:ok, reference} | {:error, any}
   @callback async_request(method, url, headers, body) :: result
   @callback done?(reference, any) :: boolean
 end

--- a/lib/timber/transports/http/hackney_client.ex
+++ b/lib/timber/transports/http/hackney_client.ex
@@ -37,7 +37,7 @@ defmodule Timber.Transports.HTTP.HackneyClient do
   ]
 
   @doc false
-  def start do
+  def start_link do
     children = [:hackney_pool.child_spec(get_pool_name(), get_pool_options())]
     opts = [strategy: :one_for_one, name: __MODULE__.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/timber/transports/http/hackney_client.ex
+++ b/lib/timber/transports/http/hackney_client.ex
@@ -36,6 +36,13 @@ defmodule Timber.Transports.HTTP.HackneyClient do
     max_connections: 2 # number of connections maintained in the pool
   ]
 
+  @doc false
+  def start do
+    children = [:hackney_pool.child_spec(get_pool_name(), get_pool_options())]
+    opts = [strategy: :one_for_one, name: __MODULE__.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
   defp config, do: Application.get_env(:timber, :hackney_client, [])
 
   @doc false

--- a/test/support/stubbing.ex
+++ b/test/support/stubbing.ex
@@ -1,10 +1,6 @@
 defmodule Timber.Stubbing do
   defmacro __using__(_) do
     quote do
-      def start do
-        start_link()
-      end
-
       def start_link do
         Agent.start_link(fn -> %{} end, name: __MODULE__)
       end

--- a/test/support/stubbing.ex
+++ b/test/support/stubbing.ex
@@ -1,6 +1,10 @@
 defmodule Timber.Stubbing do
   defmacro __using__(_) do
     quote do
+      def start do
+        start_link()
+      end
+
       def start_link do
         Agent.start_link(fn -> %{} end, name: __MODULE__)
       end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,3 @@
 ExUnit.start()
 
 Application.ensure_all_started(:hackney)
-
-{:ok, _pid} = Timber.FakeHTTPClient.start_link()


### PR DESCRIPTION
This removes any reference to `Timber.Transports.HTTP.HackneyClient` as it will attempt to compile that file. This files uses `:hackney` which won't exist if you aren't using the HTTP transport resulting in this warning:

```
warning: function :hackney.request/5 is undefined (module :hackney is not available)
  lib/timber/transports/http/hackney_client.ex:62
```