### PR TITLE
Add service name to client responses

### DIFF
--- a/lib/timber/events/http_client_response_event.ex
+++ b/lib/timber/events/http_client_response_event.ex
@@ -66,11 +66,13 @@ defmodule Timber.Events.HTTPClientResponseEvent do
   Message to be used when logging.
   """
   @spec message(t) :: IO.chardata
-  def message(%__MODULE__{headers: headers, status: status, time_ms: time_ms}) do
+  def message(%__MODULE__{headers: headers, service_name: service_name, status: status,
+    time_ms: time_ms})
+  do
     message = ["Outgoing HTTP response "]
     message = if service_name,
-      do: [message, service_name, " [", method, "] ", UtilsHTTP.full_path(path, query_string)],
-      else: [message, "[", method, "] ", UtilsHTTP.full_url(scheme, host, path, port, query_string)]
+      do: [message, service_name],
+      else: message
     message = [message, Integer.to_string(status), " in ", UtilsHTTP.format_time_ms(time_ms)]
     request_id = Map.get(headers || %{}, :request_id)
     if request_id,

--- a/lib/timber/events/http_client_response_event.ex
+++ b/lib/timber/events/http_client_response_event.ex
@@ -71,7 +71,7 @@ defmodule Timber.Events.HTTPClientResponseEvent do
   do
     message = ["Outgoing HTTP response "]
     message = if service_name,
-      do: [message, service_name],
+      do: [message, "from ", service_name, " "],
       else: message
     message = [message, Integer.to_string(status), " in ", UtilsHTTP.format_time_ms(time_ms)]
     request_id = Map.get(headers || %{}, :request_id)

--- a/test/lib/timber/events/http_client_response_event_test.exs
+++ b/test/lib/timber/events/http_client_response_event_test.exs
@@ -18,6 +18,12 @@ defmodule Timber.Events.HTTPClientResponseEventTest do
   end
 
   describe "Timber.Events.HTTPClientResponseEvent.message/1" do
+    test "includes the service name" do
+      event = HTTPClientResponseEvent.new(service_name: "timber", status: 200, time_ms: 502.2)
+      message = HTTPClientResponseEvent.message(event)
+      assert String.Chars.to_string(message) == "Outgoing HTTP response from timber 200 in 502.20ms"
+    end
+
     test "includes request id" do
       headers = [{"x-request-id", "value"}, {"user-agent", "agent"}]
       event = HTTPClientResponseEvent.new(headers: headers, status: 200, time_ms: 502.2)


### PR DESCRIPTION
Add `service_name` to HTTP client responses.