### PR TITLE
Support tags and time_ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,39 @@ Logger.info("My log message")
 
 </p></details>
 
+<details><summary><strong>Tagging logs</strong></summary><p>
+
+Need a quick way to identify logs? Use tags!:
+
+```elixir
+Logger.info("My log message", tags: ["tag"])
+
+# My log message @metadata {"level": "info", "tags": ["tag"], "context": {...}}
+```
+
+---
+
+</p></details>
+
+<details><summary><strong>Timings & Durations</strong></summary><p>
+
+Need a quick way to identify logs? Use tags!:
+
+```elixir
+timer = Timber.start_timer()
+# ... code to time ...
+time_ms = Timber.duration_ms(timer)
+Logger.info("My log message", time_ms: time_ms)
+
+# My log message @metadata {"level": "info", "time_ms": 56.4324, "context": {...}}
+```
+
+* The `:time_ms` metadata key is supported by Timber. If present, we will display it in the interface, etc.
+
+---
+
+</p></details>
+
 <details><summary><strong>Custom events</strong></summary><p>
 
 1. Log a map (simplest)
@@ -412,6 +445,6 @@ Checkout our [docs](https://timber.io/docs) for a comprehensive list of install 
 
 ---
 
-<p align="center" style="background: #140f2a;">
+<p align="center" style="background: #221f40;">
 <a href="http://github.com/timberio/timber-elixir"><img src="http://files.timber.io/images/ruby-library-readme-log-truth.png" height="947" /></a>
 </p>

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -26,7 +26,7 @@ defmodule Timber.LogEntry do
   alias Timber.Utils.Map, as: UtilsMap
   alias Timber.LogfmtEncoder
 
-  defstruct context: %{}, dt: nil, level: nil, message: nil, event: nil
+  defstruct context: %{}, dt: nil, level: nil, message: nil, event: nil, tags: nil, time_ms: nil
 
   @type format :: :json | :logfmt
 
@@ -35,7 +35,9 @@ defmodule Timber.LogEntry do
     level: LoggerBackend.level,
     message: LoggerBackend.message,
     context: Context.t,
-    event: Event.t | nil
+    event: Event.t | nil,
+    tags: nil | [String.t],
+    time_ms: nil | float
   }
 
   @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.2/schema.json"
@@ -71,7 +73,9 @@ defmodule Timber.LogEntry do
       level: level,
       event: event,
       message: message,
-      context: context
+      context: context,
+      tags: Keyword.get(metadata, :tags),
+      time_ms: Keyword.get(metadata, :time_ms)
     }
   end
 

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -40,7 +40,7 @@ defmodule Timber.LogEntry do
     time_ms: nil | float
   }
 
-  @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.2/schema.json"
+  @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.4/schema.json"
 
   @doc """
   Creates a new `LogEntry` struct

--- a/test/lib/timber/log_entry_test.exs
+++ b/test/lib/timber/log_entry_test.exs
@@ -11,6 +11,16 @@ defmodule Timber.Events.LogEntryTest do
          event: %Timber.Events.CustomEvent{data: %{}, type: :type},
          level: :info, message: "message"}
     end
+
+    test "adds tags" do
+      entry = LogEntry.new(time(), :info, "message", [tags: ["tag1", "tag2"]])
+      assert entry.tags == ["tag1", "tag2"]
+    end
+
+    test "adds time_ms" do
+      entry = LogEntry.new(time(), :info, "message", [time_ms: 56.4])
+      assert entry.time_ms == 56.4
+    end
   end
 
   describe "Timber.LogEntry.to_string!/3" do


### PR DESCRIPTION
Closes https://github.com/timberio/timber-elixir/issues/78

Adds support for `:tags` and `:time_ms` metadata attributes.