### PR TITLE
Remove hackney pool

### DIFF
--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -66,13 +66,7 @@ defmodule Timber do
       :error_logger.tty(false)
     end
 
-    http_client = Timber.Config.http_client()
-    children =
-      if http_client do
-        [worker(http_client, [])]
-      else
-        []
-      end
+    children = []
 
     opts = [strategy: :one_for_one, name: Timber.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -33,7 +33,6 @@ defmodule Timber.Transports.HTTP.Client do
   @type url :: String.t
   @type result :: {:ok, reference} | {:error, atom}
 
-  @callback start_link :: {:ok, reference} | {:error, any}
   @callback async_request(method, url, headers, body) :: result
   @callback done?(reference, any) :: boolean
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
 ExUnit.start()
 
 Application.ensure_all_started(:hackney)
+
+{:ok, _pid} = Timber.FakeHTTPClient.start_link()


### PR DESCRIPTION
This removes the pool as some people are having issue starting the `:timber` application. Clients can setup a pool separately if they need it.

Closes https://github.com/timberio/timber-elixir/issues/87