### PR TITLE
Fix msgpax application deps for OTP releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,7 @@ defmodule Timber.Mixfile do
 
   # Default list of applications to be loaded regardless
   # of Mix environment
-  defp apps(), do: [:poison, :logger]
+  defp apps(), do: [:poison, :logger, :msgpax]
 
   # The environment to be configured by default
   defp env() do


### PR DESCRIPTION
Per title, the msgpax application isn't listed causing it to be omitted from releases packaged with distillery and resulting in a crash at runtime.