### PR TITLE
Handle request timeouts

### DIFF
--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -138,7 +138,7 @@ defmodule Timber.Transports.HTTP do
     state
   end
 
-  defp wait_on_request(%{ref: ref} = state) do
+  defp wait_on_request(%{ref: ref}) do
     Config.http_client!().wait_on_request(ref)
   end
 

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -31,14 +31,15 @@ defmodule Timber.Transports.HTTP do
   alias Timber.Config
   alias Timber.LogEntry
 
-  @typep t :: %__MODULE__{
+  @type t :: %__MODULE__{
     api_key: String.t,
     buffer_size: non_neg_integer,
-    buffer: [] | [IO.chardata],
+    buffer: buffer,
     flush_interval: non_neg_integer,
     max_buffer_size: pos_integer,
     ref: reference
   }
+  @type buffer :: [] | [IO.chardata]
 
   @content_type "application/msgpack"
   @default_max_buffer_size 5000 # 5000 log line should be well below 5mb
@@ -77,24 +78,11 @@ defmodule Timber.Transports.HTTP do
   end
 
   @doc false
-  @spec write(LogEntry.t, t) :: {:ok, t}
-  def write(log_entry, state) do
-    # Write to the buffer immediately because we want to batch lines and send
-    # them on an interval.
-    state = write_buffer(log_entry, state)
-
-    if state.buffer_size >= state.max_buffer_size do
-      # The buffer is full, flush immediately.
-      {:ok, flush(state)}
-    else
-      {:ok, state}
-    end
-  end
-
-  # Writes a log entry into the buffer
-  @spec write_buffer(LogEntry.t, t) :: t
-  defp write_buffer(log_entry, %{buffer: buffer, buffer_size: buffer_size} = state) do
-    %{state | buffer: [log_entry | buffer], buffer_size: buffer_size + 1}
+  @spec flush(t) :: t
+  def flush(state) do
+    state
+    |> issue_request()
+    |> wait_on_request()
   end
 
   # Handle the outlet step, this recursively calls through process messaging via
@@ -108,9 +96,31 @@ defmodule Timber.Transports.HTTP do
       |> outlet()
     {:ok, new_state}
   end
+
   # Do nothing for everything else.
   def handle_info(_, state) do
     {:ok, state}
+  end
+
+  @doc false
+  @spec write(LogEntry.t, t) :: {:ok, t}
+  def write(log_entry, state) do
+    # Write to the buffer immediately because we want to batch lines and send
+    # them on an interval.
+    state = write_buffer(log_entry, state)
+
+    if buffer_full?(state) do
+      # The buffer is full, flush immediately.
+      {:ok, flush(state)}
+    else
+      {:ok, state}
+    end
+  end
+
+  # Writes a log entry into the buffer
+  @spec write_buffer(LogEntry.t, t) :: t
+  defp write_buffer(log_entry, %{buffer: buffer, buffer_size: buffer_size} = state) do
+    %{state | buffer: [log_entry | buffer], buffer_size: buffer_size + 1}
   end
 
   # The outlet recursively calls itself through process messaging via `Process.send_after/3`.
@@ -122,14 +132,6 @@ defmodule Timber.Transports.HTTP do
     state
   end
 
-  @doc false
-  @spec flush(t) :: t
-  def flush(state) do
-    state
-    |> issue_request()
-    |> wait_on_request()
-  end
-
   # Waits for the async request to complete
   @spec wait_on_request(t) :: t
   defp wait_on_request(%{ref: nil} = state) do
@@ -137,16 +139,7 @@ defmodule Timber.Transports.HTTP do
   end
 
   defp wait_on_request(%{ref: ref} = state) do
-    receive do
-      message ->
-        # Defer message detection to the client. Each client will have different
-        # messages and the check should be contained in there.
-        if Config.http_client!().done?(ref, message) do
-          %{state | ref: nil}
-        else
-          wait_on_request(state)
-        end
-    end
+    Config.http_client!().wait_on_request(ref)
   end
 
   # Delivers the buffer contents to Timber asynchronously using the provided HTTP client.
@@ -158,33 +151,67 @@ defmodule Timber.Transports.HTTP do
   end
 
   defp issue_request(%{api_key: api_key, buffer: buffer} = state) do
-    log_entries =
-      buffer
-      |> Enum.reverse()
-      |> Enum.map(&LogEntry.to_map!/1)
-      |> Enum.map(fn
-        %{message: nil} = log_entry_map -> log_entry_map
-
-        log_entry_map ->
-          Map.put(log_entry_map, :message, IO.chardata_to_string(log_entry_map.message))
-      end)
-
-    {:ok, body} = Msgpax.pack(log_entries)
-
+    body = buffer_to_msg_pack(buffer)
     auth_token = Base.encode64(api_key)
     vsn = Application.spec(:timber, :vsn)
     user_agent = "Timber Elixir/#{vsn} (HTTP)"
-    headers = %{
-      "Authorization" => "Basic #{auth_token}",
-      "Content-Type" => @content_type,
-      "User-Agent" => user_agent
-    }
+
+    headers =
+      %{
+        "Authorization" => "Basic #{auth_token}",
+        "Content-Type" => @content_type,
+        "User-Agent" => user_agent
+      }
+
     url = Config.http_url() || @url
 
-    {:ok, ref} = Config.http_client!().async_request(:post, url, headers, body)
+    case Config.http_client!().async_request(:post, url, headers, body) do
+      {:ok, ref} ->
+        new_buffer = clear_buffer(state)
+        %{ new_buffer | ref: ref }
 
-    %{state | ref: ref, buffer: [], buffer_size: 0}
+      {:error, _reason} ->
+        # If the buffer is full and we can't send the request, drop the messages.
+        if buffer_full?(state) do
+          clear_buffer(state)
+        else
+          # Ignore errors, keep the buffer, and allow the next attempt to retry.
+          state
+        end
+    end
   end
+
+  @spec buffer_full?(t) :: boolean
+  defp buffer_full?(state) do
+    state.buffer_size >= state.max_buffer_size
+  end
+
+  @spec clear_buffer(t) :: t
+  defp clear_buffer(state) do
+    %{ state | buffer: [], buffer_size: 0 }
+  end
+
+  # Encodes the buffer into msgpack
+  @spec buffer_to_msg_pack(buffer) :: IO.chardata
+  defp buffer_to_msg_pack(buffer) do
+    buffer
+    |> Enum.reverse()
+    |> Enum.map(&LogEntry.to_map!/1)
+    |> Enum.map(&prepare_for_msgpax/1)
+    |> Msgpax.pack!()
+  end
+
+  # Normalizes the LogEntry.message into a string if it is not.
+  @spec prepare_for_msgpax(LogEntry.t) :: LogEntry.t
+  defp prepare_for_msgpax(%{message: nil} = log_entry), do: log_entry
+
+  defp prepare_for_msgpax(log_entry_map) do
+    Map.put(log_entry_map, :message, IO.chardata_to_string(log_entry_map.message))
+  end
+
+  #
+  # Config
+  #
 
   @spec config() :: Keyword.t
   defp config, do: Application.get_env(:timber, :http_transport, [])

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -34,5 +34,5 @@ defmodule Timber.Transports.HTTP.Client do
   @type result :: {:ok, reference} | {:error, atom}
 
   @callback async_request(method, url, headers, body) :: result
-  @callback done?(reference, any) :: boolean
+  @callback wait_on_request(reference) :: :ok
 end

--- a/test/support/installer/fake_file.ex
+++ b/test/support/installer/fake_file.ex
@@ -2,18 +2,18 @@ defmodule Timber.Installer.FakeFile do
   use Timber.Stubbing
 
   def close(file) do
-    get_stub(:close).(file)
+    get_stub!(:close).(file)
   end
 
   def exists?(file) do
-    get_stub(:exists?).(file)
+    get_stub!(:exists?).(file)
   end
 
   def open(path, opts) do
-    get_stub(:open).(path, opts)
+    get_stub!(:open).(path, opts)
   end
 
   def read(path) do
-    get_stub(:read).(path)
+    get_stub!(:read).(path)
   end
 end

--- a/test/support/installer/fake_http_client.ex
+++ b/test/support/installer/fake_http_client.ex
@@ -2,6 +2,6 @@ defmodule Timber.Installer.FakeHTTPClient do
   use Timber.Stubbing
 
   def request!(session_id, method, path, opts \\ []) do
-    get_stub(:request!).(session_id, method, path, opts)
+    get_stub!(:request!).(session_id, method, path, opts)
   end
 end

--- a/test/support/installer/fake_io.ex
+++ b/test/support/installer/fake_io.ex
@@ -2,12 +2,12 @@ defmodule Timber.Installer.FakeIO do
   use Timber.Stubbing
 
   def binwrite(file, contents) do
-    get_stub(:binwrite).(file, contents)
+    get_stub!(:binwrite).(file, contents)
   end
 
   def gets(message) do
     write_output(message)
-    v = get_stub(:gets).(message)
+    v = get_stub!(:gets).(message)
     write_output(v)
     v
   end

--- a/test/support/stubbing.ex
+++ b/test/support/stubbing.ex
@@ -23,7 +23,11 @@ defmodule Timber.Stubbing do
       end
 
       def get_stub(name) do
-        Agent.get(__MODULE__, &Map.get(&1, String.to_atom("#{name}_stub"))) || raise("No stub found for #{__MODULE__}.#{name}")
+        Agent.get(__MODULE__, &Map.get(&1, String.to_atom("#{name}_stub")))
+      end
+
+      def get_stub!(name) do
+        get_stub(name) || raise("No stub found for #{__MODULE__}.#{name}")
       end
     end
   end


### PR DESCRIPTION
Handles HTTP connection timeouts. If the buffer is full when this happens, it drops the buffer. If it is not, it keeps the buffer for the next retry.

Closes https://github.com/timberio/timber-elixir-private/issues/36