### PR TITLE
Pass API key explicily when sending test logs

### DIFF
--- a/lib/mix/tasks/timber/install/platform.ex
+++ b/lib/mix/tasks/timber/install/platform.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.Timber.Install.Platform do
     |> IOHelper.write()
 
     {:ok, http_client} = Timber.Transports.HTTP.init()
+    {:ok, http_client} = Timber.Transports.HTTP.configure([api_key: api_key], http_client)
 
     log_entries = TestThePipes.log_entries()
 

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -196,10 +196,15 @@ defmodule Timber.Transports.HTTP do
   defmodule NoTimberAPIKeyError do
     defexception message: \
       """
-      We couldn't not locate your Timber API key. Please specify it
-      in your configuration:
+      We couldn't not locate your Timber API key. If you specified it
+      as an environment variable, please ensure that this variable was
+      added to your environment. Otherwise, please ensure that the
+      api_key is specified during configuration:
 
-      config :timber, api_key: "my_api_key"
+      config :timber, api_key: "my_timber_api_key"
+
+      You can location your API key in the timber console by creating or
+      editing your app: https://app.timber.io
       """
   end
 end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -28,6 +28,7 @@ defmodule Timber.Transports.HTTP do
 
   @behaviour Timber.Transport
 
+  alias __MODULE__.NoTimberAPIKeyError
   alias Timber.Config
   alias Timber.LogEntry
 
@@ -68,12 +69,7 @@ defmodule Timber.Transports.HTTP do
     api_key = Keyword.get(options, :api_key, current_api_key)
     max_buffer_size = Keyword.get(options, :max_buffer_size, @default_max_buffer_size)
     new_state = %{ state | api_key: api_key, max_buffer_size: max_buffer_size }
-
-    if api_key == nil do
-      {:error, :no_api_key}
-    else
-      {:ok, new_state}
-    end
+    {:ok, new_state}
   end
 
   @doc false
@@ -157,6 +153,10 @@ defmodule Timber.Transports.HTTP do
     state
   end
 
+  defp issue_request(%{api_key: nil}) do
+    raise NoTimberAPIKeyError
+  end
+
   defp issue_request(%{api_key: api_key, buffer: buffer} = state) do
     log_entries =
       buffer
@@ -188,4 +188,18 @@ defmodule Timber.Transports.HTTP do
 
   @spec config() :: Keyword.t
   defp config, do: Application.get_env(:timber, :http_transport, [])
+
+  #
+  # Errors
+  #
+
+  defmodule NoTimberAPIKeyError do
+    defexception message: \
+      """
+      We couldn't not locate your Timber API key. Please specify it
+      in your configuration:
+
+      config :timber, api_key: "my_api_key"
+      """
+  end
 end

--- a/test/lib/timber/transports/http_test.exs
+++ b/test/lib/timber/transports/http_test.exs
@@ -18,7 +18,7 @@ defmodule Timber.Transports.HTTPTest do
   end
 
   describe "Timber.Transports.HTTP.configure/2" do
-    test "does not request an API key" do
+    test "does not require an API key" do
       {:ok, state} = HTTP.init()
       result = HTTP.configure([api_key: nil], state)
       assert elem(result, 0) == :ok
@@ -38,6 +38,16 @@ defmodule Timber.Transports.HTTPTest do
   end
 
   describe "Timber.Transports.HTTP.flush/0" do
+    test "without an api key" do
+      entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
+      {:ok, state} = HTTP.init()
+      {:ok, state} = HTTP.configure([api_key: nil], state)
+      {:ok, state} = HTTP.write(entry, state)
+      assert_raise Timber.Transports.HTTP.NoTimberAPIKeyError, fn ->
+        HTTP.flush(state)
+      end
+    end
+
     test "issues a request" do
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init()

--- a/test/lib/timber/transports/http_test.exs
+++ b/test/lib/timber/transports/http_test.exs
@@ -18,10 +18,10 @@ defmodule Timber.Transports.HTTPTest do
   end
 
   describe "Timber.Transports.HTTP.configure/2" do
-    test "requires an API key" do
+    test "does not request an API key" do
       {:ok, state} = HTTP.init()
       result = HTTP.configure([api_key: nil], state)
-      assert result == {:error, :no_api_key}
+      assert elem(result, 0) == :ok
     end
 
     test "updates the api key" do


### PR DESCRIPTION
Resolves issues where the API key is set in the environment variable, not inline.