### PR TITLE
HTTP cleanup

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :logger, :utc_log, true
 config :logger, :handle_otp_reports, false
 
 config :logger, backends: [Timber.LoggerBackend]
-config :timber, transport: Timber.Transports.IODevice
+config :timber, transport: Timber.Transports.IODevice, debug_io_device: :stdio
 
 
 # The file config/config.secret.exs can be used for local

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :logger, :utc_log, true
 config :logger, :handle_otp_reports, false
 
 config :logger, backends: [Timber.LoggerBackend]
-config :timber, transport: Timber.Transports.IODevice, debug_io_device: :stdio
+config :timber, transport: Timber.Transports.IODevice
 
 
 # The file config/config.secret.exs can be used for local

--- a/lib/mix/tasks/timber/install/platform.ex
+++ b/lib/mix/tasks/timber/install/platform.ex
@@ -15,8 +15,7 @@ defmodule Mix.Tasks.Timber.Install.Platform do
     Messages.action_starting("Sending a few test logs...")
     |> IOHelper.write()
 
-    {:ok, http_client} = Timber.Transports.HTTP.init()
-    {:ok, http_client} = Timber.Transports.HTTP.configure([api_key: api_key], http_client)
+    {:ok, http_client} = Timber.Transports.HTTP.init([api_key: api_key])
 
     log_entries = TestThePipes.log_entries()
 

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -59,7 +59,7 @@ defmodule Timber do
      false
   end
 
-  def debug(io_device, message_fun) do
+  def debug(io_device, message_fun) when is_function(message_fun) do
     IO.write(io_device, message_fun.())
   end
 

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -49,6 +49,21 @@ defmodule Timber do
   defdelegate duration_ms(timer), to: Timber.Timer
 
   @doc false
+  def debug(message_fun) do
+    Timber.Config.debug_io_device()
+    |> debug(message_fun)
+  end
+
+  @doc false
+  def debug(nil, _message_fun) do
+     false
+  end
+
+  def debug(io_device, message_fun) do
+    IO.write(io_device, message_fun.())
+  end
+
+  @doc false
   # Handles the application callback start/2
   #
   # Starts an empty supervisor in order to comply with callback expectations

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -20,6 +20,14 @@ defmodule Timber.Config do
   end
 
   @doc """
+  Prints a variety of messages to specified IO device. We can't use the logger directly,
+  because it would create an infinite loop of logging :(
+  """
+  def debug_io_device do
+    Application.get_env(@env_key, :debug_io_device)
+  end
+
+  @doc """
   Change the name of the `Logger` metadata key that Timber uses for events.
   By default, this is `:event`
 
@@ -58,7 +66,7 @@ defmodule Timber.Config do
   config :timber, :http_client, MyCustomHTTPClient
   ```
   """
-  def http_client!, do: Application.fetch_env!(@env_key, :http_client)
+  def http_client, do: Application.get_env(@env_key, :http_client)
 
   @doc """
   Alternate URL for delivering logs. This is helpful if you want to use a proxy,

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -20,8 +20,9 @@ defmodule Timber.Config do
   end
 
   @doc """
-  Prints a variety of messages to specified IO device. We can't use the logger directly,
-  because it would create an infinite loop of logging :(
+  Helpful to inspect internal Timber activity; a useful debugging utility.
+  If specified, Timber will write messages to this device. We cannot use the
+  standard Logger directly because it would create an infinite loop.
   """
   def debug_io_device do
     Application.get_env(@env_key, :debug_io_device)

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -58,12 +58,14 @@ defmodule Timber.Transports.HTTP do
             ref: nil
 
   @doc false
-  @spec init() :: {:ok, t} | {:error, atom}
-  def init() do
-    config = [
-      api_key: Timber.Config.api_key(),
-      http_client: Timber.Config.http_client()
-    ]
+  @spec init(Keyword.t) :: {:ok, t} | {:error, atom}
+  def init(opts \\ []) do
+    config =
+      [
+        api_key: Timber.Config.api_key(),
+        http_client: Timber.Config.http_client()
+      ]
+      |> Keyword.merge(opts)
 
     with {:ok, state} <- configure(config, %__MODULE__{}),
          state <- outlet(state),

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -191,7 +191,7 @@ defmodule Timber.Transports.HTTP do
 
     case http_client.async_request(:post, url, headers, body) do
       {:ok, ref} ->
-        Timber.debug fn -> "Issued HTTP request with reference #{ref}" end
+        Timber.debug fn -> "Issued HTTP request with reference #{inspect(ref)}" end
 
         new_buffer = clear_buffer(state)
         %{ new_buffer | ref: ref }
@@ -199,7 +199,7 @@ defmodule Timber.Transports.HTTP do
       {:error, reason} ->
         # If the buffer is full and we can't send the request, drop the buffer.
         if buffer_full?(state) do
-          Timber.debug fn -> "Error issuing HTTP request #{reason}. Buffer is full, dropping messages." end
+          Timber.debug fn -> "Error issuing HTTP request #{inspect(reason)}. Buffer is full, dropping messages." end
 
           new_state = clear_buffer(state)
 
@@ -210,7 +210,9 @@ defmodule Timber.Transports.HTTP do
 
           new_state
         else
-          Timber.debug fn -> "Error issuing HTTP request #{reason}. Keeping buffer for retry next time." end
+          Timber.debug fn ->
+            "Error issuing HTTP request #{inspect(reason)}. Keeping buffer for retry next time."
+          end
           # Ignore errors, keep the buffer, and allow the next attempt to retry.
           state
         end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -63,7 +63,7 @@ defmodule Timber.Transports.HTTP do
       http_client: Timber.Config.http_client()
     ]
 
-    Timber.debug("Initialize HTTP client with #{inspect(config)}")
+    Timber.debug fn -> "Initialize HTTP client with #{inspect(config)}" end
 
     with {:ok, state} <- configure(config, %__MODULE__{}),
          state <- outlet(state),
@@ -128,7 +128,7 @@ defmodule Timber.Transports.HTTP do
   # by the specified interval length.
   @spec outlet(t) :: t
   defp outlet(%{flush_interval: flush_interval} = state) do
-    Timber.debug("Checking for logs to send, buffer size is #{state.buffer_size}")
+    Timber.debug fn -> "Checking for logs to send, buffer size is #{state.buffer_size}" end
     Process.send_after(self(), :outlet, flush_interval)
     state
   end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -32,6 +32,8 @@ defmodule Timber.Transports.HTTP do
   alias Timber.Config
   alias Timber.LogEntry
 
+  require Logger
+
   @type t :: %__MODULE__{
     api_key: String.t,
     buffer_size: non_neg_integer,

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -63,6 +63,8 @@ defmodule Timber.Transports.HTTP do
       http_client: Timber.Config.http_client()
     ]
 
+    Timber.debug("Initialize HTTP client with #{inspect(config)}")
+
     with {:ok, state} <- configure(config, %__MODULE__{}),
          state <- outlet(state),
          do: {:ok, state}
@@ -126,6 +128,7 @@ defmodule Timber.Transports.HTTP do
   # by the specified interval length.
   @spec outlet(t) :: t
   defp outlet(%{flush_interval: flush_interval} = state) do
+    Timber.debug("Checking for logs to send, buffer size is #{state.buffer_size}")
     Process.send_after(self(), :outlet, flush_interval)
     state
   end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -58,6 +58,8 @@ defmodule Timber.Transports.HTTP do
   @doc false
   @spec init() :: {:ok, t} | {:error, atom}
   def init() do
+    raise NoTimberAPIKeyError
+
     config = [
       api_key: Timber.Config.api_key(),
       http_client: Timber.Config.http_client()

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -22,7 +22,7 @@ defmodule Timber.Transports.HTTP.Client do
   Then specify it in your configuration:
 
   ```elixir
-  config :timber, :http_transport, http_client: MyHTTPClient
+  config :timber, :http_client, MyHTTPClient
   ```
   """
 

--- a/lib/timber/transports/http/hackney_client.ex
+++ b/lib/timber/transports/http/hackney_client.ex
@@ -47,15 +47,15 @@ if Code.ensure_loaded?(:hackney) do
     def wait_on_request(ref) do
       receive do
         {:hackney_response, ^ref, {:ok, status, reason}} ->
-          Timber.debug fn -> "HTTP request #{ref} received response #{status} #{reason}" end
+          Timber.debug fn -> "HTTP request #{inspect(ref)} received response #{status} #{reason}" end
           wait_on_request(ref)
 
         {:hackney_response, ^ref, {:error, error}} ->
-          Timber.debug fn -> "HTTP request #{ref} received error #{error}" end
+          Timber.debug fn -> "HTTP request #{inspect(ref)} received error #{inspect(error)}" end
           wait_on_request(ref)
 
         {:hackney_response, ^ref, :done} ->
-          Timber.debug fn -> "HTTP request #{ref} done" end
+          Timber.debug fn -> "HTTP request #{inspect(ref)} done" end
           :ok
 
         _else -> wait_on_request(ref)

--- a/test/lib/timber/transports/http_test.exs
+++ b/test/lib/timber/transports/http_test.exs
@@ -18,10 +18,11 @@ defmodule Timber.Transports.HTTPTest do
   end
 
   describe "Timber.Transports.HTTP.configure/2" do
-    test "does not require an API key" do
+    test "requires an API key" do
       {:ok, state} = HTTP.init()
-      result = HTTP.configure([api_key: nil], state)
-      assert elem(result, 0) == :ok
+      assert_raise Timber.Transports.HTTP.NoTimberAPIKeyError, fn ->
+        HTTP.configure([api_key: nil], state)
+      end
     end
 
     test "updates the api key" do
@@ -40,9 +41,9 @@ defmodule Timber.Transports.HTTPTest do
   describe "Timber.Transports.HTTP.flush/0" do
     test "without an api key" do
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
-      {:ok, state} = HTTP.init()
-      {:ok, state} = HTTP.configure([api_key: nil], state)
+      {:ok, state} = HTTP.init([api_key: "api_key"])
       {:ok, state} = HTTP.write(entry, state)
+      state = %{ state | api_key: nil }
       assert_raise Timber.Transports.HTTP.NoTimberAPIKeyError, fn ->
         HTTP.flush(state)
       end


### PR DESCRIPTION
Raises errors during `configure` if an API key or a HTTP client is not present. Adds support for `Timber.debug` which will write debug messages to `config :timber, :debug_io_device`.