### PR TITLE
Run a preflight check to ensure that the API key is valid

### DIFF
--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -28,7 +28,7 @@ defmodule Timber.Transports.HTTP do
 
   @behaviour Timber.Transport
 
-  alias __MODULE__.{NoHTTPClientError, NoTimberAPIKeyError}
+  alias __MODULE__.{NoHTTPClientError, NoTimberAPIKeyError, TimberAPIKeyInvalid}
   alias Timber.Config
   alias Timber.LogEntry
 
@@ -47,7 +47,8 @@ defmodule Timber.Transports.HTTP do
   @content_type "application/msgpack"
   @default_max_buffer_size 5000 # 5000 log line should be well below 5mb
   @default_flush_interval 1000
-  @url "https://logs.timber.io/frames"
+  @frames_url "https://logs.timber.io/frames"
+  @preflight_url "https://api.timber.io/application"
 
   defstruct api_key: nil,
             buffer_size: 0,
@@ -84,6 +85,8 @@ defmodule Timber.Transports.HTTP do
     if new_state.http_client == nil do
       raise NoHTTPClientError
     end
+
+    run_http_preflight_check!(new_state.http_client, new_state.api_key)
 
     {:ok, new_state}
   end
@@ -189,7 +192,7 @@ defmodule Timber.Transports.HTTP do
         "User-Agent" => user_agent
       }
 
-    url = Config.http_url() || @url
+    url = Config.http_url() || @frames_url
 
     case http_client.async_request(:post, url, headers, body) do
       {:ok, ref} ->
@@ -249,6 +252,19 @@ defmodule Timber.Transports.HTTP do
     Map.put(log_entry_map, :message, IO.chardata_to_string(log_entry_map.message))
   end
 
+  defp run_http_preflight_check!(http_client, api_key) do
+    headers = %{
+      "Authorization" => "Bearer #{api_key}"
+    }
+
+    case http_client.request(:get, @preflight_url, headers, "") do
+      {:ok, 204, _, _} ->
+        :ok
+      _ ->
+        raise TimberAPIKeyInvalid
+    end
+  end
+
   #
   # Errors
   #
@@ -273,7 +289,20 @@ defmodule Timber.Transports.HTTP do
 
         config :timber, api_key: "my_timber_api_key"
 
-      You can location your API key in the timber console by creating or
+      You can location your API key in the Timber console by creating or
+      editing your app: https://app.timber.io
+      """
+  end
+
+  defmodule TimberAPIKeyInvalid do
+    defexception message: \
+      """
+      The Timber service does not recognize your API key. Please check
+      that you have specified your key correctly.
+
+        config :timber, api_key: "my_timber_api_key"
+
+      You can location your API key in the Timber console by creating or
       editing your app: https://app.timber.io
       """
   end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -305,7 +305,7 @@ defmodule Timber.Transports.HTTP do
 
         config :timber, api_key: "my_timber_api_key"
 
-      You can location your API key in the Timber console by creating or
+      You can locate your API key in the Timber console by creating or
       editing your app: https://app.timber.io
       """
     defexception [:api_key, message: @message]

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -264,7 +264,7 @@ defmodule Timber.Transports.HTTP do
       {:ok, 204, _, _} ->
         :ok
       _ ->
-        raise TimberAPIKeyInvalid
+        raise TimberAPIKeyInvalid, api_key: api_key
     end
   end
 
@@ -298,7 +298,7 @@ defmodule Timber.Transports.HTTP do
   end
 
   defmodule TimberAPIKeyInvalid do
-    defexception message: \
+    @message \
       """
       The Timber service does not recognize your API key. Please check
       that you have specified your key correctly.
@@ -308,5 +308,6 @@ defmodule Timber.Transports.HTTP do
       You can location your API key in the Timber console by creating or
       editing your app: https://app.timber.io
       """
+    defexception [:api_key, message: @message]
   end
 end

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -48,7 +48,7 @@ defmodule Timber.Transports.HTTP do
   @default_max_buffer_size 5000 # 5000 log line should be well below 5mb
   @default_flush_interval 1000
   @frames_url "https://logs.timber.io/frames"
-  @preflight_url "https://api.timber.io/application"
+  @preflight_url "https://api.timber.io/installer/application"
 
   defstruct api_key: nil,
             buffer_size: 0,

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -254,8 +254,10 @@ defmodule Timber.Transports.HTTP do
   end
 
   defp run_http_preflight_check!(http_client, api_key) do
+    auth_token = Base.encode64(api_key)
+
     headers = %{
-      "Authorization" => "Bearer #{api_key}"
+      "Authorization" => "Basic #{auth_token}"
     }
 
     case http_client.request(:get, @preflight_url, headers, "") do

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -261,7 +261,7 @@ defmodule Timber.Transports.HTTP do
     }
 
     case http_client.request(:get, @preflight_url, headers, "") do
-      {:ok, 204, _, _} ->
+      {:ok, status, _, _} when status in 200..299 ->
         :ok
       _ ->
         raise TimberAPIKeyInvalid, api_key: api_key

--- a/lib/timber/transports/http.ex
+++ b/lib/timber/transports/http.ex
@@ -86,6 +86,7 @@ defmodule Timber.Transports.HTTP do
       raise NoHTTPClientError
     end
 
+    new_state.http_client.start()
     run_http_preflight_check!(new_state.http_client, new_state.api_key)
 
     {:ok, new_state}

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -34,6 +34,7 @@ defmodule Timber.Transports.HTTP.Client do
   @type async_result :: {:ok, reference} | {:error, atom}
   @type result :: {:ok, integer, map, String.t} | {:error, atom}
 
+  @callback start() :: :ok
   @callback async_request(method, url, headers, body) :: async_result
   @callback request(method, url, headers, body) :: result
   @callback wait_on_request(reference) :: :ok

--- a/lib/timber/transports/http/client.ex
+++ b/lib/timber/transports/http/client.ex
@@ -31,8 +31,10 @@ defmodule Timber.Transports.HTTP.Client do
   @type method :: atom
   @type status :: pos_integer
   @type url :: String.t
-  @type result :: {:ok, reference} | {:error, atom}
+  @type async_result :: {:ok, reference} | {:error, atom}
+  @type result :: {:ok, integer, map, String.t} | {:error, atom}
 
-  @callback async_request(method, url, headers, body) :: result
+  @callback async_request(method, url, headers, body) :: async_result
+  @callback request(method, url, headers, body) :: result
   @callback wait_on_request(reference) :: :ok
 end

--- a/lib/timber/transports/http/hackney_client.ex
+++ b/lib/timber/transports/http/hackney_client.ex
@@ -27,6 +27,12 @@ if Code.ensure_loaded?(:hackney) do
       recv_timeout: 10_000 #  10 seconds, timeout to receive a response
     ]
 
+    def start() do
+      {:ok, _} = Application.ensure_all_started(:hackney)
+
+      :ok
+    end
+
     @doc """
     Issues a HTTP request via hackney.
     """

--- a/lib/timber/transports/http/hackney_client.ex
+++ b/lib/timber/transports/http/hackney_client.ex
@@ -30,12 +30,23 @@ if Code.ensure_loaded?(:hackney) do
     @doc """
     Issues a HTTP request via hackney.
     """
-    @spec async_request(Client.method, Client.url, Client.headers, Client.body) :: Client.result
     def async_request(method, url, headers, body) do
       req_headers = Enum.map(headers, &(&1))
       req_opts =
         get_request_options()
         |> Keyword.merge([async: true])
+
+      :hackney.request(method, url, req_headers, body, req_opts)
+    end
+
+    @doc """
+    Issues a HTTP request via hackney.
+    """
+    def request(method, url, headers, body) do
+      req_headers = Enum.map(headers, &(&1))
+      req_opts =
+        get_request_options()
+        |> Keyword.merge([with_body: true])
 
       :hackney.request(method, url, req_headers, body, req_opts)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,7 @@ defmodule Timber.Mixfile do
 
   # Default list of applications to be loaded regardless
   # of Mix environment
-  defp apps(), do: [:poison, :logger, :msgpax]
+  defp apps(), do: [:poison, :logger, :msgpax, :hackney]
 
   # The environment to be configured by default
   defp env() do

--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,7 @@ defmodule Timber.Mixfile do
 
   # Default list of applications to be loaded regardless
   # of Mix environment
-  defp apps(), do: [:poison, :logger, :msgpax, :hackney]
+  defp apps(), do: [:poison, :logger, :msgpax]
 
   # The environment to be configured by default
   defp env() do

--- a/test/lib/timber/transports/http_test.exs
+++ b/test/lib/timber/transports/http_test.exs
@@ -7,7 +7,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.init/0" do
     test "configures properly" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -16,7 +16,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "starts the flusher" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -27,7 +27,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.configure/2" do
     test "raises when the API key is not present" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -40,9 +40,9 @@ defmodule Timber.Transports.HTTPTest do
 
     test "raises when the API key is invalid" do
       FakeHTTPClient.stub :request, fn
-        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
-        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer invalid"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer invalid"}, _ ->
           {:ok, 401, %{}, ""}
       end
 
@@ -55,9 +55,9 @@ defmodule Timber.Transports.HTTPTest do
 
     test "updates the api key" do
       FakeHTTPClient.stub :request, fn
-        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer new_api_key"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer new_api_key"}, _ ->
           {:ok, 204, %{}, ""}
-        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -67,7 +67,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "updates the max_buffer_size" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -79,7 +79,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.flush/0" do
     test "without an api key" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -93,7 +93,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "issues a request" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -117,7 +117,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "issues a request with chardata" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -135,7 +135,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "http client returns an error" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -161,7 +161,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.handle_info/2" do
     test "handles the outlet properly" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -176,7 +176,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "ignores everything else" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -194,7 +194,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.write/0" do
     test "buffers the message if the buffer is not full" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -207,7 +207,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "flushes if the buffer is full" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
         {:ok, 204, %{}, ""}
       end
 

--- a/test/lib/timber/transports/http_test.exs
+++ b/test/lib/timber/transports/http_test.exs
@@ -7,31 +7,70 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.init/0" do
     test "configures properly" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       {:ok, state} = HTTP.init()
       assert state.api_key == "api_key"
     end
 
     test "starts the flusher" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+      end
+
       HTTP.init()
       assert_receive(:outlet, 1100)
     end
   end
 
   describe "Timber.Transports.HTTP.configure/2" do
-    test "requires an API key" do
+    test "raises when the API key is not present" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+      end
+
       {:ok, state} = HTTP.init()
+
       assert_raise Timber.Transports.HTTP.NoTimberAPIKeyError, fn ->
         HTTP.configure([api_key: nil], state)
       end
     end
 
+    test "raises when the API key is invalid" do
+      FakeHTTPClient.stub :request, fn
+        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer invalid"}, _ ->
+          {:ok, 401, %{}, ""}
+      end
+
+      {:ok, state} = HTTP.init()
+
+      assert_raise Timber.Transports.HTTP.TimberAPIKeyInvalid, fn ->
+        HTTP.configure([api_key: "invalid"], state)
+      end
+    end
+
     test "updates the api key" do
+      FakeHTTPClient.stub :request, fn
+        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer new_api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+        :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+      end
+
       {:ok, state} = HTTP.init()
       {:ok, new_state} = HTTP.configure([api_key: "new_api_key"], state)
       assert new_state.api_key == "new_api_key"
     end
 
     test "updates the max_buffer_size" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+      end
+
       {:ok, state} = HTTP.init()
       {:ok, new_state} = HTTP.configure([max_buffer_size: 100], state)
       assert new_state.max_buffer_size == 100
@@ -40,6 +79,10 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.flush/0" do
     test "without an api key" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init([api_key: "api_key"])
       {:ok, state} = HTTP.write(entry, state)
@@ -50,6 +93,10 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "issues a request" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init()
       {:ok, state} = HTTP.write(entry, state)
@@ -70,6 +117,10 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "issues a request with chardata" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, ["this", "is", "a", "message"], [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init()
       {:ok, state} = HTTP.write(entry, state)
@@ -84,6 +135,10 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "http client returns an error" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
 
       expected_method = :post
@@ -106,6 +161,10 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.handle_info/2" do
     test "handles the outlet properly" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init()
       {:ok, state} = HTTP.write(entry, state)
@@ -117,6 +176,10 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "ignores everything else" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       {:ok, state} = HTTP.init()
       {:ok, new_state} = HTTP.handle_info(:unknown, state)
       assert state == new_state
@@ -131,6 +194,10 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.write/0" do
     test "buffers the message if the buffer is not full" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+          {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init()
       {:ok, new_state} = HTTP.write(entry, state)
@@ -140,6 +207,10 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "flushes if the buffer is full" do
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        {:ok, 204, %{}, ""}
+      end
+
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
       {:ok, state} = HTTP.init()
       state = %{state | max_buffer_size: 1}

--- a/test/lib/timber/transports/http_test.exs
+++ b/test/lib/timber/transports/http_test.exs
@@ -7,7 +7,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.init/0" do
     test "configures properly" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -16,7 +16,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "starts the flusher" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -27,7 +27,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.configure/2" do
     test "raises when the API key is not present" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -40,9 +40,9 @@ defmodule Timber.Transports.HTTPTest do
 
     test "raises when the API key is invalid" do
       FakeHTTPClient.stub :request, fn
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer invalid"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic aW52YWxpZA=="}, _ ->
           {:ok, 401, %{}, ""}
       end
 
@@ -55,9 +55,9 @@ defmodule Timber.Transports.HTTPTest do
 
     test "updates the api key" do
       FakeHTTPClient.stub :request, fn
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer new_api_key"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic bmV3X2FwaV9rZXk="}, _ ->
           {:ok, 204, %{}, ""}
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -67,7 +67,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "updates the max_buffer_size" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -79,7 +79,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.flush/0" do
     test "without an api key" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -93,7 +93,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "issues a request" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -117,7 +117,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "issues a request with chardata" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -135,7 +135,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "http client returns an error" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -161,7 +161,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.handle_info/2" do
     test "handles the outlet properly" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -176,7 +176,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "ignores everything else" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 
@@ -194,7 +194,7 @@ defmodule Timber.Transports.HTTPTest do
 
   describe "Timber.Transports.HTTP.write/0" do
     test "buffers the message if the buffer is not full" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
           {:ok, 204, %{}, ""}
       end
 
@@ -207,7 +207,7 @@ defmodule Timber.Transports.HTTPTest do
     end
 
     test "flushes if the buffer is full" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Bearer api_key"}, _ ->
+      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
         {:ok, 204, %{}, ""}
       end
 

--- a/test/support/fake_http_client.ex
+++ b/test/support/fake_http_client.ex
@@ -20,6 +20,12 @@ defmodule Timber.FakeHTTPClient do
     end
   end
 
+  def request(method, url, headers, body) do
+    add_function_call(:request, {method, url, headers, body})
+    stub = get_stub(:request)
+    stub.(method, url, headers, body)
+  end
+
   def wait_on_request(ref) do
     receive do
       {:hackney_response, ^ref, :done} -> :ok

--- a/test/support/fake_http_client.ex
+++ b/test/support/fake_http_client.ex
@@ -1,6 +1,10 @@
 defmodule Timber.FakeHTTPClient do
   use Timber.Stubbing
 
+  def start() do
+    :ok
+  end
+
   def async_request(method, url, headers, body) do
     # Track the function call
     add_function_call(:async_request, {method, url, headers, body})


### PR DESCRIPTION
This calls out to the Timber API and verifies that the API key used is valid before continuing the configuration.

Closes #95 