### PR TITLE
Adds the metadata key to configuration at install

### DIFF
--- a/lib/mix/tasks/timber/install/config_file.ex
+++ b/lib/mix/tasks/timber/install/config_file.ex
@@ -52,7 +52,8 @@ defmodule Mix.Tasks.Timber.Install.ConfigFile do
         # Fall back to the default `:console` backend with the Timber custom formatter
         config :logger,
           backends: [:console],
-          format: {Timber.Formatter, :format}
+          format: {Timber.Formatter, :format},
+          metadata: [:timber_context, :event]
 
         config :timber, Timber.Formatter,
           colorize: true,
@@ -76,7 +77,8 @@ defmodule Mix.Tasks.Timber.Install.ConfigFile do
     # it to use Timber's internal formatting system
     config :logger,
       backends: [:console],
-      format: {Timber.Formatter, :format}
+      format: {Timber.Formatter, :format},
+      metadata: [:timber_context, :event]
     """
   end
 

--- a/test/lib/mix/tasks/timber/install/config_file_test.exs
+++ b/test/lib/mix/tasks/timber/install/config_file_test.exs
@@ -64,14 +64,16 @@ defmodule Mix.Tasks.Timber.Install.ConfigFileTest do
         # it to use Timber's internal formatting system
         config :logger,
           backends: [:console],
-          format: {Timber.Formatter, :format}
+          format: {Timber.Formatter, :format},
+          metadata: [:timber_context, :event]
 
         # For dev / test environments, always log to STDOUt and format the logs properly
         if Mix.env() == :dev || Mix.env() == :test do
           # Fall back to the default `:console` backend with the Timber custom formatter
           config :logger,
             backends: [:console],
-            format: {Timber.Formatter, :format}
+            format: {Timber.Formatter, :format},
+            metadata: [:timber_context, :event]
 
           config :timber, Timber.Formatter,
             colorize: true,

--- a/test/support/installer/fake_file_contents.ex
+++ b/test/support/installer/fake_file_contents.ex
@@ -287,14 +287,16 @@ defmodule Timber.Installer.FakeFileContents do
     # it to use Timber's internal formatting system
     config :logger,
       backends: [:console],
-      format: {Timber.Formatter, :format}
+      format: {Timber.Formatter, :format},
+      metadata: [:timber_context, :event]
 
     # For dev / test environments, always log to STDOUt and format the logs properly
     if Mix.env() == :dev || Mix.env() == :test do
       # Fall back to the default `:console` backend with the Timber custom formatter
       config :logger,
         backends: [:console],
-        format: {Timber.Formatter, :format}
+        format: {Timber.Formatter, :format},
+        metadata: [:timber_context, :event]
 
       config :timber, Timber.Formatter,
         colorize: true,


### PR DESCRIPTION
In order to be used appropriately with the `:console` backend, Timber needs to have the `:timber_context` and `:event` metadata keys exposed. Without these keys, it will not be able to print the added context or event.

This change adds the necessary `:metadata` key in the configuration file that exposes the metadata to the formatter.

This fixes the issue that @binarylogic pointed out in #110

Closes #117 