### PR TITLE
Fixes Plug session detection

### DIFF
--- a/lib/timber/integrations/context_plug.ex
+++ b/lib/timber/integrations/context_plug.ex
@@ -72,13 +72,7 @@ defmodule Timber.Integrations.ContextPlug do
   """
   @spec call(Plug.Conn.t, Plug.opts) :: Plug.Conn.t
   def call(%{method: method, request_path: request_path} = conn, opts) do
-    conn = ensure_session_id(conn)
-    session_id = Plug.Conn.get_session(conn, @session_id_key)
-
-    if session_id do
-      %SessionContext{id: session_id}
-      |> Timber.add_context()
-    end
+    conn = initialize_session_id(conn)
 
     request_id_header = Keyword.get(opts, :request_id_header, "x-request-id")
     remote_addr = PlugUtils.get_client_ip(conn)
@@ -99,16 +93,54 @@ defmodule Timber.Integrations.ContextPlug do
     conn
   end
 
-  defp ensure_session_id(conn) do
-    # Plug does not expose the actual id, so we need to make our own.
-    conn = Plug.Conn.fetch_session(conn)
-    existing_session_id = Plug.Conn.get_session(conn, @session_id_key)
+  @spec initialize_session_id(Plug.Conn.t) :: Plug.Conn.t
+  # Attempts to retrieve or initialize the Timber session ID.
+  #
+  # Timber assigns a unique, 32 character ID to every session. Once assigned, Timber
+  # is able to retrieve it for the duration of the session, so even on subsequent
+  # requests, the session ID remains the same.
+  #
+  # The session ID is then added to the Timber context as a side-effect. This prevents
+  # it being added if sessions are not being used.
+  #
+  # In order to retrieve the session, the session plug must already have been
+  # defined. If it hasn't been, fetching the session will cause an `ArgumentError`
+  # exception to be raised. In this case, the exception is rescued and the
+  #
+  defp initialize_session_id(conn) do
+    # We make sure the session has been fetched and loaded onto the conn. This call has
+    # the chance to raise if Plug doesn't have an adapter for sessions. If that's the
+    # case, the exception is rescued in the `rescue` section below.
+    session_conn = Plug.Conn.fetch_session(conn)
+    # Now that we've confirmed a session is loaded, we try to retrieve the session ID
+    # from Timber's custom session key. If this doesn't exist, we generate one.
+    #
+    # We make sure to put the session_id on the session at the end of this function,
+    # so we don't concern ourselves with that here.
+    session_id =
+      case Plug.Conn.get_session(session_conn, @session_id_key) do
+        nil ->
+          generate_session_id()
+        id ->
+          id
+      end
 
-    if !existing_session_id do
-      Plug.Conn.put_session(conn, @session_id_key, generate_session_id())
-    else
+    # We set up the session context and assign it to the Timber context here.
+    # This is the safest place to do it, since we've confirmed that the session is
+    # being used and a session ID has been generated. This is a side-effect, and we
+    # don't return anything about it to the caller function.
+    %SessionContext{id: session_id}
+    |> Timber.add_context()
+
+    # We ensure that we set the session_id on the session here, regardless of whether
+    # it was set before. This change is idempotent if it was already present.
+    Plug.Conn.put_session(session_conn, @session_id_key, session_id)
+  rescue
+    ArgumentError ->
+      # If no session Plug has been defined, the call to `Plug.Conn.fetch_session/1`
+      # will raise an ArgumentError. In this case, we return the original conn
+      # from the function parameters
       conn
-    end
   end
 
   defp generate_session_id do


### PR DESCRIPTION
The Plug session was being fetched, but when the session is fetched but there's no logic to fetch it, Plug raises an error. We now handle this more gracefully.