### PR TITLE
Capture params for controller call events

### DIFF
--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -19,16 +19,26 @@ defmodule Timber.Event do
   @doc false
   @spec to_api_map(t) :: map
   def to_api_map(%Events.CustomEvent{type: type} = event) when is_binary(type) do
-    to_api_map(%{event | type: String.to_atom(type)})
+    atom_type = String.to_atom(type)
+
+    %{event | type: atom_type}
+    |> to_api_map()
   end
 
   def to_api_map(%Events.CustomEvent{type: type, data: data}) do
     %{custom: %{type => data}}
   end
 
+  def to_api_map(%Events.ControllerCallEvent{} = event) do
+    type = type(event)
+    map = Events.ControllerCallEvent.to_api_map(event)
+    %{server_side_app: %{type => map}}
+  end
+
   def to_api_map(event) do
     type = type(event)
-    %{server_side_app: %{type => Map.from_struct(event)}}
+    map = Map.from_struct(event)
+    %{server_side_app: %{type => map}}
   end
 
   @doc """

--- a/lib/timber/events/controller_call_event.ex
+++ b/lib/timber/events/controller_call_event.ex
@@ -5,21 +5,61 @@ defmodule Timber.Events.ControllerCallEvent do
   """
 
   @type t :: %__MODULE__{
-    action: String.t | nil,
-    controller: String.t | nil,
+    action: String.t,
+    controller: String.t,
+    params_json: String.t | nil,
   }
 
   @enforce_keys [:action, :controller]
   defstruct [
     :action,
-    :controller
+    :controller,
+    :params_json,
+    :pipelines
   ]
+
+  @params_json_limit 5_000
+
+  @doc """
+  Builds a new struct taking care to:
+
+  * Convert `:params` to `:params_json` that satifies the Timber API requirements
+  """
+  @spec new(Keyword.t) :: t
+  def new(opts) do
+    params = Keyword.get(opts, :params)
+    params_json =
+      if params do
+        params
+        |> Timber.Utils.JSON.encode!()
+        |> to_string() # TODO: see if we can avoid this, we need it for the truncation below
+        |> String.slice(0..(@params_json_limit - 1))
+      else
+        nil
+      end
+
+    %__MODULE__{
+      action: Keyword.get(opts, :action),
+      controller: Keyword.get(opts, :controller),
+      params_json: params_json,
+      pipelines: Keyword.get(opts, :pipelines)
+    }
+  end
 
   @doc """
   Message to be used when logging.
   """
   @spec message(t) :: IO.chardata
-  def message(%__MODULE__{action: action, controller: controller}) do
-    ["Processing by ", controller, ?., action]
+  def message(%__MODULE__{action: action, controller: controller, pipelines: pipelines}) do
+    ["Processing with ", controller, ?., action, ?/, ?2, ?\n, "  Pipelines: ", inspect(pipelines)]
+  end
+
+  @doc """
+  Converts the struct into a map that the Timber API expects. This is the data
+  that is sent to the Timber API.
+  """
+  @spec to_api_map(t) :: map
+  def to_api_map(%__MODULE__{action: action, controller: controller, params_json: params_json}) do
+    %{action: action, controller: controller, params_json: params_json}
   end
 end

--- a/lib/timber/events/http_client_request_event.ex
+++ b/lib/timber/events/http_client_request_event.ex
@@ -40,7 +40,7 @@ defmodule Timber.Events.HTTPClientRequestEvent do
     headers: map | nil,
     host: String.t,
     method: String.t,
-    path: String.t,
+    path: String.t | nil,
     port: pos_integer | nil,
     query_string: String.t | nil,
     request_id: String.t | nil,
@@ -61,7 +61,7 @@ defmodule Timber.Events.HTTPClientRequestEvent do
   def new(opts) do
     opts =
       opts
-      |> Keyword.update(:body, nil, fn body -> UtilsHTTPEvents.normalize_body(body) end)
+      |> Keyword.delete(:body) # Don't store the body for now. We store the params in the ControllerCallEvent. We can re-enable this upon request.
       |> Keyword.update(:headers, nil, fn headers -> UtilsHTTPEvents.normalize_headers(headers) end)
       |> Keyword.update(:method, nil, &UtilsHTTPEvents.normalize_method/1)
       |> Keyword.update(:service_name, nil, &UtilsHTTPEvents.try_atom_to_string/1)

--- a/lib/timber/events/http_server_response_event.ex
+++ b/lib/timber/events/http_server_response_event.ex
@@ -32,7 +32,7 @@ defmodule Timber.Events.HTTPServerResponseEvent do
   def new(opts) do
     opts =
       opts
-      |> Keyword.update(:body, nil, fn body -> UtilsHTTPEvents.normalize_body(body) end)
+      |> Keyword.delete(:body) # Don't store the body for now. We store the params in the ControllerCallEvent. We can re-enable this upon request.
       |> Keyword.update(:headers, nil, fn headers -> UtilsHTTPEvents.normalize_headers(headers) end)
       |> Enum.filter(fn {_k,v} -> !(v in [nil, ""]) end)
 

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -87,11 +87,15 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
 
     # Phoenix actions are always 2 arity function
     action = action_name <> "/2"
+    params = params(conn.params)
+    pipelines = conn.private[:phoenix_pipelines]
 
-    event = %ControllerCallEvent{
+    event = ControllerCallEvent.new(
       action: action,
-      controller: controller
-    }
+      controller: controller,
+      params: params,
+      pipelines: pipelines
+    )
 
     message = ControllerCallEvent.message(event)
     metadata = Timber.Utils.Logger.event_to_metadata(event)
@@ -137,5 +141,13 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
   @spec get_log_level(atom) :: atom
   defp get_log_level(default) do
     Timber.Config.phoenix_instrumentation_level(default)
+  end
+
+  defp params(%Plug.Conn.Unfetched{}), do: "[UNFETCHED]"
+
+  defp params(params) do
+    params
+    |> Phoenix.Logger.filter_values()
+    |> inspect()
   end
 end

--- a/lib/timber/utils/json.ex
+++ b/lib/timber/utils/json.ex
@@ -1,0 +1,12 @@
+defmodule Timber.Utils.JSON do
+  @moduledoc false
+
+  @doc """
+  Convenience function for encoding a value into JSON using the
+  JSON encoded set in `Timber.Config`.
+  """
+  @spec encode!(any) :: any
+  def encode!(value) do
+    Timber.Config.json_encoder().(value)
+  end
+end

--- a/test/lib/timber/event_test.exs
+++ b/test/lib/timber/event_test.exs
@@ -9,5 +9,11 @@ defmodule Timber.EventTest do
       map = Event.to_api_map(custom_event)
       assert map == %{custom: %{build: %{version: "1.0.0"}}}
     end
+
+    test "controller call event" do
+      event = %Timber.Events.ControllerCallEvent{action: "action", controller: "controller", params_json: "{\"key\": \"value\"}", pipelines: [1]}
+      map = Event.to_api_map(event)
+      assert map == %{server_side_app: %{controller_call: %{action: "action", controller: "controller", params_json: "{\"key\": \"value\"}"}}}
+    end
   end
 end

--- a/test/lib/timber/events/controller_call_event_test.exs
+++ b/test/lib/timber/events/controller_call_event_test.exs
@@ -1,0 +1,12 @@
+defmodule Timber.Events.ControllerCallEventTest do
+  use Timber.TestCase
+
+  alias Timber.Events.ControllerCallEvent
+
+  describe "Timber.Events.ControllerCallEvent.new/1" do
+    test "converts params to params_json" do
+      event = ControllerCallEvent.new(action: "action", controller: "controller", params: %{key: "value"}, pipelines: [1])
+      assert event == %ControllerCallEvent{action: "action", controller: "controller", params_json: "{\"key\":\"value\"}", pipelines: [1]}
+    end
+  end
+end


### PR DESCRIPTION
This PR bring the elixir library inline with our ruby library.

1. Captures `params` for all controller events and sends that off as metadata in the `params_json` field.
2. Updates the `ControllerCallEvent` log message to match [the default Phoenix message](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/logger.ex#L30-L32) (minus the params since we capture those in the metadata)
3. Drops recording the `body` for `HTTPServerRequestEvent` and `HTTPServerResponseEvent`. This is excessive and not that helpful. The new `body_params` attribute on the `ControllerCall` event is much more helpful as it is _post_ parsing. This way you get to the the structured representation of the body versus the raw representation (form encoded, xml, etc).
