### PR TITLE
Fix `try_atom_to_string` for nil.

### DIFF
--- a/lib/timber/utils/http_events.ex
+++ b/lib/timber/utils/http_events.ex
@@ -117,6 +117,8 @@ defmodule Timber.Utils.HTTPEvents do
 
   @doc false
   # Convenience method that checks if the value is an atom and also converts it to a string.
+  def try_atom_to_string(nil), do: nil
+
   def try_atom_to_string(val) when is_atom(val), do: Atom.to_string(val)
 
   def try_atom_to_string(val), do: val


### PR DESCRIPTION
Hi again guys,

I noticed when testing my [maxwell middleware](https://github.com/doughsay/maxwell_timber) for timber that if I create an http client request event with a `service_name` of `nil`, it actually converts it to the string `"nil"`.  I thought that might be a bit undesirable...  Here's a fix! :)