### PR TITLE
Be more defensive with stacktrace parsing

### DIFF
--- a/test/lib/timber/events/exception_event_test.exs
+++ b/test/lib/timber/events/exception_event_test.exs
@@ -41,6 +41,28 @@ defmodule Timber.Events.ExceptionEventTest do
       }
     end
 
+    test "native functions" do
+      log_message =
+        """
+        ** (exit) an exception was raised:
+            ** (ArgumentError) argument error
+                (stdlib) :ets.lookup(:noproc, 111)
+        """
+      result = ExceptionEvent.new(log_message)
+      assert result == {:error, :could_not_parse_message}
+    end
+
+    test "malformed stacktrace" do
+      log_message =
+        """
+        ** (exit) an exception was raised:
+            ** (RuntimeError) boom
+                (my_app) malformed
+        """
+      result = ExceptionEvent.new(log_message)
+      assert result == {:error, :could_not_parse_message}
+    end
+
     test "malformed message" do
       {:error, :could_not_parse_message} = ExceptionEvent.new("testing")
     end


### PR DESCRIPTION
This handles exception parsing in a more defensive manner. If parsing fails the message will be logged as a traditional text line.

Note, this resolves the issue currently. The longer term fix is to receive messages directly from the error logger system, which is a larger project we are hoping to complete in the next 2 - 3 weeks.

Closes https://github.com/timberio/timber-elixir/issues/129