### PR TITLE
Handle HTTP Responses More Effectively

### DIFF
--- a/lib/mix/tasks/timber/install.ex
+++ b/lib/mix/tasks/timber/install.ex
@@ -273,24 +273,15 @@ defmodule Mix.Tasks.Timber.Install do
   end
 
   defp check_for_http_client(api) do
-    if Code.ensure_loaded?(:hackney) do
-      API.event!(api, :http_client_found)
+    API.event!(api, :http_client_found)
 
-      case :hackney.start() do
-        :ok -> :ok
-        {:error, {:already_started, _name}} -> :ok
-        other -> other
-      end
-
-      :ok
-    else
-      API.event!(api, :http_client_not_found)
-
-      Messages.http_client_setup()
-      |> IOHelper.puts(:red)
-
-      exit :shutdown
+    case :hackney.start() do
+      :ok -> :ok
+      {:error, {:already_started, _name}} -> :ok
+      other -> other
     end
+
+    :ok
   end
 
   defp collect_feedback(api) do

--- a/lib/mix/tasks/timber/install/messages.ex
+++ b/lib/mix/tasks/timber/install/messages.ex
@@ -107,36 +107,6 @@ defmodule Mix.Tasks.Timber.Install.Messages do
     """
   end
 
-  def http_client_setup do
-    """
-    #{separator()}
-
-    Before we can proceed, you'll need to add hackney as a dependency.
-
-    This is completely normal. We opted to have you complete this step
-    so that you could choose your HTTP client instead of forcing one on you.
-
-    We recommend hackney. The process is very simple:
-
-    1. In mix.exs, add :hackney to your dependencies and applications:
-
-        def application do
-          [applications: [:hackney]]
-        end
-
-        def deps do
-          [{:hackney, "~> 1.7"}]
-        end
-
-    2. Run mix deps.get
-
-    3. Run mix deps.clean timber
-
-    All done? Quit and re-run this installer. It is perfectly safe to do so.
-    This installer is idempotent.
-    """
-  end
-
   def intro do
     """
     This installer will walk you through setting up Timber in your application.

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -57,19 +57,6 @@ defmodule Timber.Config do
   def http_body_size_limit, do: Application.get_env(@application, :http_body_size_limit, 2000)
 
   @doc """
-  Custom HTTP client to use for transmitting logs over HTTP. Timber comes packaged with a
-  `:hackney` client. See `Timber.Transports.HTTP.HackneyClient`. If you do not want to use
-  `:hackney` you can easily write your own client to handle log transport.
-
-  # Example
-
-  ```elixir
-  config :timber, :http_client, MyCustomHTTPClient
-  ```
-  """
-  def http_client, do: Application.get_env(@application, :http_client, Timber.HTTPClients.Hackney)
-
-  @doc """
   Alternate URL for delivering logs. This is helpful if you want to use a proxy,
   for example.
 

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -107,14 +107,6 @@ defmodule Timber.Config do
   end
 
   @doc """
-  Retrieves the preflight URL 
-  """
-  def preflight_url() do
-    default_preflight_url = "https://api.timber.io/installer/application"
-    Application.get_env(@application, :preflight_url, default_preflight_url)
-  end
-
-  @doc """
   Gets the transport specificed in the :timber configuration. The default is
   `Timber.Transports.IODevice`.
   """

--- a/lib/timber/http_client.ex
+++ b/lib/timber/http_client.ex
@@ -1,30 +1,5 @@
 defmodule Timber.HTTPClient do
-  @moduledoc """
-  Behavior for custom HTTP clients. If you opt not to use the default Timber HTTP client
-  (`Timber.HTTPClients.Hackney`) you can define your own by adhering to this behavior.
-
-  ## Example
-
-  ```elixir
-  defmodule MyHTTPClient do
-    alias Timber.HTTPClient
-
-    @behaviour HTTPClient
-
-    @spec request(HTTPClient.method, HTTPClient.url, HTTPClient.headers, HTTPClient.body, HTTPClient.options) ::
-      {:ok, HTTPClient.status, HTTPClient.Headers, HTTPClient.body} | {:error, any()}
-    def request(method, url, headers, body, opts) do
-      # make request here
-    end
-  end
-  ```
-
-  Then specify it in your configuration:
-
-  ```elixir
-  config :timber, :http_client, MyHTTPClient
-  ```
-  """
+  @moduledoc false
 
   @type body :: IO.chardata
   @type headers :: map
@@ -37,5 +12,4 @@ defmodule Timber.HTTPClient do
   @callback start() :: :ok
   @callback async_request(method, url, headers, body) :: async_result
   @callback request(method, url, headers, body) :: result
-  @callback wait_on_request(reference) :: :ok
 end

--- a/lib/timber/http_clients/hackney.ex
+++ b/lib/timber/http_clients/hackney.ex
@@ -56,28 +56,6 @@ defmodule Timber.HTTPClients.Hackney do
     :hackney.request(method, url, req_headers, body, req_opts)
   end
 
-  @doc """
-  Takes a reference to an async request and waits for it to complete.
-  """
-  @spec wait_on_request(reference) :: :ok
-  def wait_on_request(ref) do
-    receive do
-      {:hackney_response, ^ref, {:ok, status, reason}} ->
-        Timber.debug fn -> "HTTP request #{inspect(ref)} received response #{status} #{reason}" end
-        wait_on_request(ref)
-
-      {:hackney_response, ^ref, {:error, error}} ->
-        Timber.debug fn -> "HTTP request #{inspect(ref)} received error #{inspect(error)}" end
-        wait_on_request(ref)
-
-      {:hackney_response, ^ref, :done} ->
-        Timber.debug fn -> "HTTP request #{inspect(ref)} done" end
-        :ok
-
-      _else -> wait_on_request(ref)
-    end
-  end
-
   #
   # Config
   #

--- a/lib/timber/logger_backends/http.ex
+++ b/lib/timber/logger_backends/http.ex
@@ -21,26 +21,12 @@ defmodule Timber.LoggerBackends.HTTP do
   previous (first) request is still being processed, then the transport will enter
   synchronous mode, waiting for a response before proceeding with the request.
   Synchronous mode will cause any logging calls to block until the request completes.
-
-  ## Configuration
-
-  ### Custom HTTP client
-
-  The HTTP backend can use any HTTP client, so long as it supports asynchronous requests.
-  Suport for `:hackney` is built into the library and is the default client, supported via
-  `Timber.Transports.HTTP.HackneyClient`. You can define your own custom HTTP client by adhering
-  to the `Timber.Transports.HTTP.Client` behaviour. Afterwards, you must specify your client
-  in the configuration:
-
-  ```
-  config :timber, :http_client, MyHTTPClient
-  ```
   """
   use GenEvent
 
   alias Timber.LogEntry
   alias Timber.Config
-  alias __MODULE__.{NoHTTPClientError, NoTimberAPIKeyError, TimberAPIKeyInvalid}
+  alias __MODULE__.{NoTimberAPIKeyError, TimberAPIKeyInvalid}
 
   require Logger
 
@@ -104,6 +90,9 @@ defmodule Timber.LoggerBackends.HTTP do
   @default_flush_interval 1000
   @frames_url "https://logs.timber.io/frames"
 
+  # Despite there being an `http_client` field, this is only for testing; the HTTP client is
+  # not actually configurable since it's impossible to support clients when we do not understand
+  # the response messages in advance
   defstruct min_level: nil,
             api_key: nil,
             buffer_size: 0,
@@ -187,6 +176,13 @@ defmodule Timber.LoggerBackends.HTTP do
     {:ok, new_state}
   end
 
+  # Handles responses for asynchronous requests from Hackney for the last request made;
+  # note that any other requests will fail the ref=ref pattern match and fall to the next
+  # handle_info/2 definition
+  def handle_info(msg = {:hackney_response, ref, _}, state = %{ref: ref}) do
+    handle_hackney_response(msg, state)
+  end
+
   # Do nothing for everything else.
   def handle_info(_, state) do
     {:ok, state}
@@ -199,7 +195,7 @@ defmodule Timber.LoggerBackends.HTTP do
   defp configure(options, state) do
     api_key = Keyword.get(options, :api_key, Timber.Config.api_key())
     flush_interval = Keyword.get(options, :flush_interval, state.flush_interval)
-    http_client = Keyword.get(options, :http_client, Timber.Config.http_client())
+    http_client = Keyword.get(options, :http_client, Timber.HTTPClients.Hackney)
     max_buffer_size = Keyword.get(options, :max_buffer_size, state.max_buffer_size)
     min_level = Keyword.get(options, :min_level, state.min_level)
 
@@ -215,10 +211,6 @@ defmodule Timber.LoggerBackends.HTTP do
 
     if new_state.api_key == nil do
       raise NoTimberAPIKeyError
-    end
-
-    if new_state.http_client == nil do
-      raise NoHTTPClientError
     end
 
     new_state.http_client.start()
@@ -264,18 +256,34 @@ defmodule Timber.LoggerBackends.HTTP do
     {:ok, state}
   end
 
-  # Waits for the async request to complete
   @spec wait_on_request(t) :: t
+  # Blocks until the last asynchronous request is received
+  #
+  # The function first checks whether there is a reference to a previous request.
+  # If there isn't, it returns immediately.
+  #
+  # If there is an existing request, the function enters a `receive` block to look
+  # for responses from Hackney. If it cannot find a response after 5 seconds, it will
+  # abandon the previous request. If it finds a response, it sends it to the
+  # handle_hackney_response/2 function which modifies the state apropriately based on
+  # the message. It then loops on the new state.
+  #
   defp wait_on_request(%{ref: nil} = state) do
     state
   end
 
-  defp wait_on_request(%{http_client: nil}) do
-    raise NoHTTPClientError
-  end
+  defp wait_on_request(state = %{ref: ref}) do
+    receive do
+      {:hackney_response, ^ref, msg} ->
+        {:ok, new_state} = handle_hackney_response({:hackney_response, ref, msg}, state)
 
-  defp wait_on_request(%{http_client: http_client, ref: ref}) do
-    http_client.wait_on_request(ref)
+        wait_on_request(new_state)
+      after 5000 ->
+        Timber.debug fn -> "HTTP request #{inspect(ref)} exceeded timeout; abandoning it." end
+
+        new_state = %{ state | ref: nil }
+        wait_on_request(new_state)
+    end
   end
 
   # Delivers the buffer contents to Timber asynchronously using the provided HTTP client.
@@ -288,10 +296,6 @@ defmodule Timber.LoggerBackends.HTTP do
 
   defp issue_request(%{api_key: nil}) do
     raise NoTimberAPIKeyError
-  end
-
-  defp issue_request(%{http_client: nil}) do
-    raise NoHTTPClientError
   end
 
   defp issue_request(%{api_key: api_key, buffer: buffer, buffer_size: buffer_size,
@@ -381,19 +385,51 @@ defmodule Timber.LoggerBackends.HTTP do
     Logger.compare_levels(lvl, min) != :lt
   end
 
+  @spec handle_hackney_response({:hackney_response, reference, term}, t) :: {:ok, t}
+  # Handles responses from Hackney asynchronous requests and modifies the state appropriately
+  #
+  # This function assumes that its caller has already matched the reference being given to
+  # the one existing in the state
+  defp handle_hackney_response({:hackney_response, ref, {:ok, 401, reason}}, state) do
+    Timber.debug fn -> "HTTP request #{inspect(ref)} received response 401 #{reason}" end
+
+    raise TimberAPIKeyInvalid, status: 401, api_key: state.api_key
+  end
+
+  defp handle_hackney_response({:hackney_response, ref, {:ok, 403, reason}}, state) do
+    Timber.debug fn -> "HTTP request #{inspect(ref)} received response 403 #{reason}" end
+
+    {:ok, state}
+  end
+
+  defp handle_hackney_response({:hackney_response, ref, {:ok, status, reason}}, state) do
+    Timber.debug fn -> "HTTP request #{inspect(ref)} received response #{status} #{reason}" end
+
+    {:ok, state}
+  end
+
+  defp handle_hackney_response({:hackney_response, ref, {:error, error}}, state) do
+    # In the event of an error on Hackney's part, we simply clear the reference.
+    Timber.debug fn -> "HTTP request #{inspect(ref)} received error #{inspect(error)}" end
+
+    new_state = %{ state | ref: nil }
+    {:ok, new_state}
+  end
+
+  defp handle_hackney_response({:hackney_response, ref, :done}, state) do
+    Timber.debug fn -> "HTTP request #{inspect(ref)} done" end
+
+    new_state = %{ state | ref: nil }
+    {:ok, new_state}
+  end
+
+  defp handle_hackney_response({:hackney_response, _ref, _}, state) do
+    {:ok, state}
+  end
+
   #
   # Errors
   #
-
-  defmodule NoHTTPClientError do
-    defexception message: \
-      """
-      An HTTP client could not be found. Timber allows you to choose your HTTP
-      client, but comes with a default :hackney click. Please use this via:
-
-        config :timber, http_client: Timber.Transports.HTTP.HackneyClient
-      """
-  end
 
   defmodule NoTimberAPIKeyError do
     defexception message: \

--- a/lib/timber/logger_backends/http.ex
+++ b/lib/timber/logger_backends/http.ex
@@ -222,7 +222,6 @@ defmodule Timber.LoggerBackends.HTTP do
     end
 
     new_state.http_client.start()
-    run_http_preflight_check!(new_state.http_client, new_state.api_key)
 
     {:ok, new_state}
   end
@@ -380,24 +379,6 @@ defmodule Timber.LoggerBackends.HTTP do
 
   defp event_level_adequate?(lvl, min) do
     Logger.compare_levels(lvl, min) != :lt
-  end
-
-  defp run_http_preflight_check!(http_client, api_key) do
-    auth_token = Base.encode64(api_key)
-    preflight_url = Config.preflight_url()
-
-    headers = %{
-      "Authorization" => "Basic #{auth_token}"
-    }
-
-    case http_client.request(:get, preflight_url, headers, "") do
-      {:ok, status, _, _} when status in 200..299 ->
-        :ok
-      {:ok, status, _, _} ->
-        raise TimberAPIKeyInvalid, api_key: api_key, status: status
-      _ ->
-        raise TimberAPIKeyInvalid, api_key: api_key
-    end
   end
 
   #

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule Timber.Mixfile do
 
   # Default list of applications to be loaded regardless
   # of Mix environment
-  defp apps(), do: [:poison, :logger, :msgpax]
+  defp apps(), do: [:logger, :poison, :msgpax, :hackney]
 
   # The environment to be configured by default
   defp env() do
@@ -160,7 +160,7 @@ defmodule Timber.Mixfile do
 
         # Hackney is pinned because other versions are known to have bugs. This is the
         # safest route.
-        {:hackney, "1.6.3 or 1.6.5 or 1.7.1", optional: true},
+        {:hackney, "1.6.3 or 1.6.5 or 1.7.1"},
         {:msgpax, "~> 1.0"},
         {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0"}
       ]

--- a/test/lib/timber/logger_backends/http_test.exs
+++ b/test/lib/timber/logger_backends/http_test.exs
@@ -38,21 +38,6 @@ defmodule Timber.LoggerBackends.HTTPTest do
       end
     end
 
-    test "{:configure, options} message raises when the API key is invalid" do
-      FakeHTTPClient.stub :request, fn
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-          {:ok, 204, %{}, ""}
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic aW52YWxpZA=="}, _ ->
-          {:ok, 401, %{}, ""}
-      end
-
-      {:ok, state} = HTTP.init(HTTP)
-
-      assert_raise Timber.LoggerBackends.HTTP.TimberAPIKeyInvalid, fn ->
-        HTTP.handle_call({:configure, [api_key: "invalid"]}, state)
-      end
-    end
-
     test "{:configure, options} message updates the api key" do
       FakeHTTPClient.stub :request, fn
         :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic bmV3X2FwaV9rZXk="}, _ ->

--- a/test/lib/timber/logger_backends/http_test.exs
+++ b/test/lib/timber/logger_backends/http_test.exs
@@ -5,12 +5,15 @@ defmodule Timber.LoggerBackends.HTTPTest do
   alias Timber.LogEntry
   alias Timber.LoggerBackends.HTTP
 
+
+  setup do
+    {:ok, state} = HTTP.init(HTTP, [http_client: FakeHTTPClient])
+
+    {:ok, state: state}
+  end
+
   describe "Timber.LoggerBackends.HTTP.init/1" do
     test "configures properly" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
-
       {:ok, state} = HTTP.init(HTTP)
       assert state.api_key == "api_key"
     end
@@ -26,65 +29,40 @@ defmodule Timber.LoggerBackends.HTTPTest do
   end
 
   describe "Timber.LoggerBackends.HTTP.handle_call/2" do
-    test "{:configure, options} message raises when the API key is inil" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-          {:ok, 204, %{}, ""}
-      end
-
-      {:ok, state} = HTTP.init(HTTP)
-
+    test "{:configure, options} message raises when the API key is nil", %{state: state} do
       assert_raise Timber.LoggerBackends.HTTP.NoTimberAPIKeyError, fn ->
         HTTP.handle_call({:configure, [api_key: nil]}, state)
       end
     end
 
-    test "{:configure, options} message updates the api key" do
-      FakeHTTPClient.stub :request, fn
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic bmV3X2FwaV9rZXk="}, _ ->
-          {:ok, 204, %{}, ""}
-        :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-          {:ok, 204, %{}, ""}
-      end
-
-      {:ok, state} = HTTP.init(HTTP)
+    test "{:configure, options} message updates the api key", %{state: state} do
       {:ok, :ok, new_state} = HTTP.handle_call({:configure, [api_key: "new_api_key"]}, state)
       assert new_state.api_key == "new_api_key"
     end
 
-    test "{:configure, options} message updates the max_buffer_size" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-          {:ok, 204, %{}, ""}
-      end
-
-      {:ok, state} = HTTP.init(HTTP)
+    test "{:configure, options} message updates the max_buffer_size", %{state: state} do
       {:ok, :ok, new_state} = HTTP.handle_call({:configure, [max_buffer_size: 100]}, state)
       assert new_state.max_buffer_size == 100
     end
   end
 
   describe "Timber.LoggerBackends.HTTP.handle_event/2" do
-    test ":flush message raises without an api key" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-          {:ok, 204, %{}, ""}
-      end
-
+    test ":flush message raises without an api key", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
-      {:ok, state} = HTTP.init(HTTP)
+
       {:ok, :ok, state} = HTTP.handle_call({:configure, [api_key: "api_key"]}, state)
       {:ok, state} = HTTP.handle_event(entry, state)
+
       state = %{ state | api_key: nil }
+
       assert_raise Timber.LoggerBackends.HTTP.NoTimberAPIKeyError, fn ->
         HTTP.handle_event(:flush, state)
       end
     end
 
-    test ":flush message issues a request" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
-
+    test ":flush message issues a request", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
-      {:ok, state} = HTTP.init(HTTP)
+
       {:ok, state} = HTTP.handle_event(entry, state)
       HTTP.handle_event(:flush, state)
 
@@ -102,13 +80,9 @@ defmodule Timber.LoggerBackends.HTTPTest do
       assert elem(call, 3) == encoded_body
     end
 
-    test ":flush message issues a request with chardata" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
-
+    test ":flush message issues a request with chardata", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
-      {:ok, state} = HTTP.init(HTTP)
+
       {:ok, state} = HTTP.handle_event(entry, state)
       HTTP.handle_event(:flush, state)
 
@@ -120,11 +94,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
       assert elem(call, 3) == encoded_body
     end
 
-    test "failure of the http client will not cause the :flush message to raise" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
-
+    test "failure of the http client will not cause the :flush message to raise", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
       expected_method = :post
@@ -139,32 +109,21 @@ defmodule Timber.LoggerBackends.HTTPTest do
         {:error, :connect_timeout}
       end
 
-      {:ok, state} = HTTP.init(HTTP)
       {:ok, state} = HTTP.handle_event(entry, state)
       {:ok, _} = HTTP.handle_event(:flush, state)
     end
 
-    test "message event buffers the message if the buffer is not full" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-          {:ok, 204, %{}, ""}
-      end
-
+    test "message event buffers the message if the buffer is not full", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
-      {:ok, state} = HTTP.init(HTTP)
       {:ok, new_state} = HTTP.handle_event(entry, state)
       assert new_state.buffer == [event_entry_to_log_entry(entry)]
       calls = FakeHTTPClient.get_async_request_calls()
       assert length(calls) == 0
     end
 
-    test "flushes if the buffer is full" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
-
+    test "flushes if the buffer is full", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
-      {:ok, state} = HTTP.init(HTTP)
       state = %{state | max_buffer_size: 1}
       HTTP.handle_event(entry, state)
       calls = FakeHTTPClient.get_async_request_calls()
@@ -173,13 +132,8 @@ defmodule Timber.LoggerBackends.HTTPTest do
   end
 
   describe "Timber.LoggerBackends.HTTP.handle_info/2" do
-    test "handles the outlet properly" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
-
+    test "handles the outlet properly", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
-      {:ok, state} = HTTP.init(HTTP)
       {:ok, state} = HTTP.handle_event(entry, state)
       {:ok, new_state} = HTTP.handle_info(:outlet, state)
       calls = FakeHTTPClient.get_async_request_calls()
@@ -188,12 +142,53 @@ defmodule Timber.LoggerBackends.HTTPTest do
       assert_receive(:outlet, 1100)
     end
 
-    test "ignores everything else" do
-      FakeHTTPClient.stub :request, fn :get, "https://api.timber.io/installer/application", %{"Authorization" => "Basic YXBpX2tleQ=="}, _ ->
-        {:ok, 204, %{}, ""}
-      end
+    test "handles successful status response message from Hackney for ongoing request", %{state: state} do
+      ref = make_ref()
+      state = %{state | ref: ref}
+      {:ok, new_state} = HTTP.handle_info({:hackney_response, ref, {:ok, 200, ""}}, state)
 
-      {:ok, state} = HTTP.init(HTTP)
+      # The state shouldn't change here since we haven't received the :done message
+      assert new_state.ref == ref
+    end
+
+    test "handles unauthorized status response message from Hackney for ongoing request", %{state: state} do
+      ref = make_ref()
+      state = %{state | ref: ref}
+
+      assert_raise Timber.LoggerBackends.HTTP.TimberAPIKeyInvalid, fn ->
+        HTTP.handle_info({:hackney_response, ref, {:ok, 401, ""}}, state)
+      end
+    end
+
+    test "handles error response message from Hackney for ongoing request", %{state: state} do
+      ref = make_ref()
+      state = %{state | ref: ref}
+      {:ok, new_state} = HTTP.handle_info({:hackney_response, ref, {:error, ""}}, state)
+
+      # The reference should have been dropped due to the error
+      assert is_nil(new_state.ref)
+    end
+
+    test "handles done response message from Hackney for ongoing request", %{state: state} do
+      ref = make_ref()
+      state = %{state | ref: ref}
+      {:ok, new_state} = HTTP.handle_info({:hackney_response, ref, :done}, state)
+
+      # The reference should have been dropped since it is complete
+      assert is_nil(new_state.ref)
+    end
+
+    test "handles response message from Hackney for orphaned request", %{state: state} do
+      orphaned_ref = make_ref()
+      ref = make_ref()
+      state = %{state | ref: ref}
+      {:ok, new_state} = HTTP.handle_info({:hackney_response, orphaned_ref, :done}, state)
+
+      # The reference should stay the same since the orphaned reference does not match
+      assert new_state.ref == ref
+    end
+
+    test "ignores everything else", %{state: state} do
       {:ok, new_state} = HTTP.handle_info(:unknown, state)
       assert state == new_state
     end


### PR DESCRIPTION
This stemmed out of the issue described in #137, but it became much larger based on issues discovered during development.

First, this removes the existing preflight check. It's being deprecated in favor of responses from the log collection API.

Second, this moves the `wait_on_request/1` functionality from the `Timber.HTTPClient` behaviour to the `Timber.LoggerBackends.HTTP` event handler. Hackney sends its response messages back to the calling process, which is the event handler in this case. The event handler is responsible for handling those messages appropriately via the `handle_info/2` function. However, the `handle_info/2` logic was never written to capture hackney responses, therefore they would have fallen through to the last function definition and been ignored.

The result of this was that hackney response messages would have been lost, and worse they wouldn't be sent again. If hackney sent a :done message for an asynchronous request and it was discarded by `handle_info/2`, the next `wait_on_request/1` call inside the `Timber.HTTPClients.Hackney` module would have looped indefinitely since the reference it was looking for would never be sent.

Also, the existing `wait_on_request/1` code was too greedy. It had a final wildcard match that would have matched any inbound message. This means that it would have matched incoming logs, system notices, and anything else that wasn't one of the hackney responses defined above it. Since those messages were matched by the wildcard, they were removed from the process message box and handed into the block's logic. That match simply called the function in a loop, so those messages were discarded into the ether.

So, now, instead of calling the `wait_on_request/1` the logic has been split into two pieces. First, the private function `handle_hackney_response/2` has been defined in the `Timber.LoggerBackends.HTTP` module. It takes the message from hackney as its first parameter and the current state of the event handler as its second. Its responsibilty is as follows:

  - If the API returns a 401 (unauthorized) response, it raises an error causing the event handler to crash. This is expected functionality.
  - Otherwise, it waits until it receives either a done or error message to clear the current reference in the state.

The `handle_hackney_response/2` should be called when the message being matched also matches the current ref.

Actually receiving the message is now the work of `handle_info/2` as well as the private function `wait_on_request/1` (inside `Timber.LoggerBackends.HTTP`). `handle_info/2` is part of the sequential processing of messages by the event handler. When hackney sends a response message to the event handler and the event handler is not in a `wait_on_request/1` loop, the message is given to `handle_info/2` if it matches the current ref. It then calls `handle_hackney_response/2` to modify the state appropriately.

`wait_on_request/1` is called when the event handler needs to block until the previous request has finished. It works by looping until the ref in the state has been cleared. If there is a ref, it iterates over the current process message box looking for hackney responses for that ref. If it finds one, it hands it off to `handle_hackney_response/2` to modify the state appropriately and then loop. If the state is modified such that the reference is cleared, the next call will exit the loop. Each call of the receive block will allow up to 5 seconds for a hackney message to appear before it times out and deems the request's reference abandoned.

An "abandoned" or "orphaned" request is just that: the request has exceeded the time the system will wait for it, and as a result, the system abandons it. Any further messages from hackney about this request will be passed through to the last function defintiion for `handle_info/2` and discarded.

As part of this change, it became clear that hackney was integrally tied ot the event handler. Because the event handler needs to know the message forms to match on for asynchronous requests. With this in mind, hackney is now a _required_ dependency of the application. The configuration field for the HTTP client remains in the HTTP backend's state but this is only for testing purposes.

Closes #137