### PR TITLE
Removes explicit reference to foreign structs

### DIFF
--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -142,7 +142,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     Timber.Config.phoenix_instrumentation_level(default)
   end
 
-  defp params(%Plug.Conn.Unfetched{}), do: %{}
+  defp params(%{__struct__: :"Elixir.Plug.Conn.Unfetched"}), do: %{}
 
   defp params(params) when is_list(params) or is_map(params) do
     params


### PR DESCRIPTION
Elixir throws an error when trying to compile a module which references a struct that doesn't exist. For example, if a user does not have Plug in their dependency list, but our code specifies a struct from the Plug package, Elixir will refuse to compile our code.

To avoid this issue, I am not relying on the Elixir compiler to do struct checking at compile time for foreign structs which might not be a user depdendency. This is done by checking the `:__struct__` field in the function head rather than specifying the module form.

For example, instead of specifying the `%Plug.Conn.Unfetched{}` struct directly, we mimic the presentation of the struct by specifing the `:"Elixir.Plug.Conn.Unfetched"` atom as the value of the `:__struct__` field.

Closes #142