### PR TITLE
Dont raise when the API key is missing

### DIFF
--- a/lib/timber/logger_backends/http.ex
+++ b/lib/timber/logger_backends/http.ex
@@ -211,11 +211,11 @@ defmodule Timber.LoggerBackends.HTTP do
 
     if new_state.api_key == nil do
       Timber.debug fn ->
-        "The Timber API key is nil! Please be sure to include an API key when configuring " <>
-          "the Timber logger."
+        "The Timber API key is nil! Please check the documentation for how to specify an API key " <>
+          "in your configuration file."
       end
     else
-      Timber.debug fn -> "The Timber API is present." end
+      Timber.debug fn -> "The Timber API key is present." end
     end
 
     new_state.http_client.start()

--- a/test/lib/timber/logger_backends/http_test.exs
+++ b/test/lib/timber/logger_backends/http_test.exs
@@ -29,12 +29,6 @@ defmodule Timber.LoggerBackends.HTTPTest do
   end
 
   describe "Timber.LoggerBackends.HTTP.handle_call/2" do
-    test "{:configure, options} message raises when the API key is nil", %{state: state} do
-      assert_raise Timber.LoggerBackends.HTTP.NoTimberAPIKeyError, fn ->
-        HTTP.handle_call({:configure, [api_key: nil]}, state)
-      end
-    end
-
     test "{:configure, options} message updates the api key", %{state: state} do
       {:ok, :ok, new_state} = HTTP.handle_call({:configure, [api_key: "new_api_key"]}, state)
       assert new_state.api_key == "new_api_key"
@@ -47,19 +41,6 @@ defmodule Timber.LoggerBackends.HTTPTest do
   end
 
   describe "Timber.LoggerBackends.HTTP.handle_event/2" do
-    test ":flush message raises without an api key", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
-
-      {:ok, :ok, state} = HTTP.handle_call({:configure, [api_key: "api_key"]}, state)
-      {:ok, state} = HTTP.handle_event(entry, state)
-
-      state = %{ state | api_key: nil }
-
-      assert_raise Timber.LoggerBackends.HTTP.NoTimberAPIKeyError, fn ->
-        HTTP.handle_event(:flush, state)
-      end
-    end
-
     test ":flush message issues a request", %{state: state} do
       entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 


### PR DESCRIPTION
This makes the HTTP device less abrasive when the API key is missing. We encountered an edge-case today where a client was receiving this error during app initialization. Regardless of the details there, the HTTP client should be less strict and log the error to our debug IO device.