### PR TITLE
Separate context plugs into HTTP and Session

### DIFF
--- a/lib/mix/tasks/timber/install/endpoint_file.ex
+++ b/lib/mix/tasks/timber/install/endpoint_file.ex
@@ -7,7 +7,8 @@ defmodule Mix.Tasks.Timber.Install.EndpointFile do
     router_pattern = ~r/( *)plug [^\n\r]*.Router/
     router_replacement =
       "\\1# Add Timber plugs for capturing HTTP context and events\n" <>
-        "\\1plug Timber.Integrations.ContextPlug\n" <>
+        "\\1plug Timber.Integrations.SessionContextPlug\n" <>
+        "\\1plug Timber.Integrations.HTTPContextPlug\n" <>
         "\\1plug Timber.Integrations.EventPlug\n\n\\0"
 
     logger_pattern = ~r/( *)plug Plug\.Logger\n?/

--- a/lib/timber/contexts/http_context.ex
+++ b/lib/timber/contexts/http_context.ex
@@ -4,7 +4,7 @@ defmodule Timber.Contexts.HTTPContext do
   being handled.
 
   Note: Timber can automatically add context information about HTTP requests if
-  you use a `Plug` based framework through the `Timber.Integrations.ContextPlug`.
+  you use a `Plug` based framework through the `Timber.Integrations.HTTPContextPlug`.
   """
 
   @type t :: %__MODULE__{

--- a/lib/timber/contexts/session_context.ex
+++ b/lib/timber/contexts/session_context.ex
@@ -4,7 +4,7 @@ defmodule Timber.Contexts.SessionContext do
   need for authentication.
 
   Note: Timber can automatically add context information about HTTP requests if
-  you use a `Plug` based framework through the `Timber.Integrations.ContextPlug`.
+  you use a `Plug` based framework through the `Timber.Integrations.SessionContextPlug`.
   """
 
   @type t :: %__MODULE__{

--- a/lib/timber/events/http_server_request_event.ex
+++ b/lib/timber/events/http_server_request_event.ex
@@ -4,8 +4,8 @@ defmodule Timber.Events.HTTPServerRequestEvent do
   insight into the HTTP requests coming into your app.
 
   Timber can automatically track incoming HTTP requests if you use a `Plug` based framework.
-  See `Timber.Integrations.ContextPlug` and `Timber.Integerations.EventPlug`. Also, the
-  `README.md` outlines how to set these up.
+  See the documentation for `Timber.Integerations.EventPlug` for more information. The `README.md`
+  also outlines how to set this up.
   """
 
   alias Timber.Utils.HTTPEvents, as: UtilsHTTPEvents

--- a/lib/timber/integrations/context_plug.ex
+++ b/lib/timber/integrations/context_plug.ex
@@ -1,152 +1,33 @@
 defmodule Timber.Integrations.ContextPlug do
   @moduledoc """
-  Automatically captures the HTTP method, path, and request_id in Plug-based frameworks
-  like Phoenix and adds it to the context.
+  Deprecated
 
-  By adding this data to the context, you'll be able to associate
-  all the log statements that occur while processing that HTTP request.
+  This module is deprecated as of version 2.3.0 and will be removed
+  in version 3.0 and beyond. Use `Timber.Integrations.HTTPContextPlug`
+  and `Timber.Integrations.SessionContextPlug` instead.
 
-  ## Adding the Plug
-
-  `Timber.Integrations.ContextPlug` can be added to your plug pipeline using the standard
-  `Plug.Builder.plug/2` macro. The point at which you place it determines
-  what state Timber will receive the connection in, therefore it's
-  recommended you place it as close to the origin of the request as
-  possible.
-
-  ### Plug (Standalone or Plug.Router)
-
-  If you are using Plug without a framework, your setup will vary depending
-  on your architecture. The call to `plug Timber.Integrations.ContextPlug` should be grouped
-  with any other plugs you call prior to performing business logic.
-
-  Timber expects query parameters to have already been fetched on the
-  connection using `Plug.Conn.fetch_query_params/2`.
-
-  ### Phoenix
-
-  Phoenix's flexibility means there are multiple points in the plug pipeline
-  where the `Timber.Integrations.ContextPlug` can be inserted. The recommended place is in
-  `endpoint.ex`. Make sure that you insert this plug immediately before your `Router` plug.
-
-  ## Request ID
-
-  Timber does its best to track the request ID for every HTTP request
-  in order to help you filter your logs responsibly. If you are calling
-  the `Plug.RequestId` plug in your pipeline, you should make sure
-  that `Timber.Integrations.ContextPlug` appears _after_ that plug so that it can pick
-  up the correct ID.
-
-  By default, Timber expects your request ID to be stored using the
-  header name "X-Request-ID" (casing irrelevant), but that may not
-  fit all needs. If you use a custom header name for your request ID,
-  you can pass that name as an option to the plug:
-
-  ```
-  plug Timber.Plug, request_id_header: "req-id"
-  ```
+  Until this module is removed, it will mimic previous functionality by
+  calling `Timber.Integrations.HTTPContextPlug` followed by
+  `Timber.Integrations.SessionContextPlug`.
   """
 
-  require Logger
-
-  alias Timber.Contexts.{HTTPContext, SessionContext}
-  alias Timber.Utils.Plug, as: PlugUtils
-
-  @session_id_key :_timber_session_id
-
   @doc """
-  Prepares the given options for use in a plug pipeline
-
-  When the `Plug.Builder.plug/2` macro is called, it will use this
-  function to prepare options. Any resulting options will be
-  passed on to the plug on every call. The options accepted
-  by this function are the same as defined by `call/2`.
+  Deprecated
   """
   @spec init(Plug.opts) :: Plug.opts
   def init(opts) do
     opts
+    |> Timber.Integrations.SessionContextPlug.init()
+    |> Timber.Integrations.HTTPContextPlug.init()
   end
 
   @doc """
-  Adds the Request ID to the Timber context data
+  Deprecated
   """
   @spec call(Plug.Conn.t, Plug.opts) :: Plug.Conn.t
-  def call(%{method: method, request_path: request_path} = conn, opts) do
-    conn = initialize_session_id(conn)
-
-    request_id_header = Keyword.get(opts, :request_id_header, "x-request-id")
-    remote_addr = PlugUtils.get_client_ip(conn)
-    request_id =
-      case PlugUtils.get_request_id(conn, request_id_header) do
-        [{_, request_id}] -> request_id
-        [] -> nil
-      end
-
-    %HTTPContext{
-      method: method,
-      path: request_path,
-      request_id: request_id,
-      remote_addr: remote_addr
-    }
-    |> Timber.add_context()
-
+  def call(conn, opts) do
     conn
-  end
-
-  @spec initialize_session_id(Plug.Conn.t) :: Plug.Conn.t
-  # Attempts to retrieve or initialize the Timber session ID.
-  #
-  # Timber assigns a unique, 32 character ID to every session. Once assigned, Timber
-  # is able to retrieve it for the duration of the session, so even on subsequent
-  # requests, the session ID remains the same.
-  #
-  # The session ID is then added to the Timber context as a side-effect. This prevents
-  # it being added if sessions are not being used.
-  #
-  # In order to retrieve the session, the session plug must already have been
-  # defined. If it hasn't been, fetching the session will cause an `ArgumentError`
-  # exception to be raised. In this case, the exception is rescued and the
-  #
-  defp initialize_session_id(conn) do
-    # We make sure the session has been fetched and loaded onto the conn. This call has
-    # the chance to raise if Plug doesn't have an adapter for sessions. If that's the
-    # case, the exception is rescued in the `rescue` section below.
-    session_conn = Plug.Conn.fetch_session(conn)
-    # Now that we've confirmed a session is loaded, we try to retrieve the session ID
-    # from Timber's custom session key. If this doesn't exist, we generate one.
-    #
-    # We make sure to put the session_id on the session at the end of this function,
-    # so we don't concern ourselves with that here.
-    session_id =
-      case Plug.Conn.get_session(session_conn, @session_id_key) do
-        nil ->
-          generate_session_id()
-        id ->
-          id
-      end
-
-    # We set up the session context and assign it to the Timber context here.
-    # This is the safest place to do it, since we've confirmed that the session is
-    # being used and a session ID has been generated. This is a side-effect, and we
-    # don't return anything about it to the caller function.
-    %SessionContext{id: session_id}
-    |> Timber.add_context()
-
-    # We ensure that we set the session_id on the session here, regardless of whether
-    # it was set before. This change is idempotent if it was already present.
-    Plug.Conn.put_session(session_conn, @session_id_key, session_id)
-  rescue
-    ArgumentError ->
-      # If no session Plug has been defined, the call to `Plug.Conn.fetch_session/1`
-      # will raise an ArgumentError. In this case, we return the original conn
-      # from the function parameters
-      conn
-  end
-
-  defp generate_session_id do
-    32
-    |> :crypto.strong_rand_bytes()
-    |> Base.encode16(case: :lower)
-    |> binary_part(0, 32)
+    |> Timber.Integrations.SessionContextPlug.call(opts)
+    |> Timber.Integrations.HTTPContextPlug.call(opts)
   end
 end

--- a/lib/timber/integrations/event_plug.ex
+++ b/lib/timber/integrations/event_plug.ex
@@ -7,7 +7,7 @@ defmodule Timber.Integrations.EventPlug do
   adding this plug to your pipeline will automatically create events
   for incoming HTTP requests and responses for your log statements.
 
-  Note: If you're using `Timber.Integrations.ContextPlug`, that plug should come before
+  Note: If you're using `Timber.Integrations.HTTPContextPlug`, that plug should come before
   `Timber.Integrations.EventPlug` in any pipeline. This will give you the best results.
 
   ## Adding the Plug

--- a/lib/timber/integrations/http_context_plug.ex
+++ b/lib/timber/integrations/http_context_plug.ex
@@ -1,0 +1,86 @@
+defmodule Timber.Integrations.HTTPContextPlug do
+  @moduledoc """
+  Automatically captures the HTTP method, path, and request_id in Plug-based frameworks
+  like Phoenix and adds it to the context.
+
+  By adding this data to the context, you'll be able to associate
+  all the log statements that occur while processing that HTTP request.
+
+  ## Adding the Plug
+
+  `Timber.Integrations.HTTPContextPlug` can be added to your plug pipeline using the
+  standard `Plug.Builder.plug/2` macro. The point at which you place it determines
+  what state Timber will receive the connection in, therefore it's recommended you place
+  it as close to the origin of the request as possible.
+
+  ### Plug (Standalone or Plug.Router)
+
+  If you are using Plug without a framework, your setup will vary depending on your
+  architecture. The call to `plug Timber.Integrations.HTTPContextPlug` should be grouped with
+  any other plugs you call prior to performing business logic.
+
+  Timber expects query parameters to have already been fetched on the connection using
+  `Plug.Conn.fetch_query_params/2`.
+
+  ### Phoenix
+
+  Phoenix's flexibility means there are multiple points in the plug pipeline
+  where the `Timber.Integrations.HTTPContextPlug` can be inserted. The recommended place is in
+  `endpoint.ex`. Make sure that you insert this plug immediately before your `Router` plug.
+
+  ## Request ID
+
+  Timber does its best to track the request ID for every HTTP request in order to help you
+  filter your logs easily. If you are calling the `Plug.RequestId` plug in your pipeline,
+  you should make sure that `Timber.Integrations.HTTPContextPlug` appears _after_ that plug so
+  that it can pick up the correct ID.
+
+  By default, Timber expects your request ID to be stored using the header name "X-Request-ID"
+  (casing irrelevant), but that may not fit all needs. If you use a custom header name for your
+  request ID, you can pass that name as an option to the plug:
+
+  ```
+  plug Timber.Plug, request_id_header: "req-id"
+  ```
+  """
+
+  alias Timber.Contexts.HTTPContext
+  alias Timber.Utils.Plug, as: PlugUtils
+
+  @doc """
+  Prepares the given options for use in a plug pipeline
+
+  When the `Plug.Builder.plug/2` macro is called, it will use this
+  function to prepare options. Any resulting options will be
+  passed on to the plug on every call. The options accepted
+  by this function are the same as defined by `call/2`.
+  """
+  @spec init(Plug.opts) :: Plug.opts
+  def init(opts) do
+    opts
+  end
+
+  @doc """
+  Adds the Request ID to the Timber context data
+  """
+  @spec call(Plug.Conn.t, Plug.opts) :: Plug.Conn.t
+  def call(%{method: method, request_path: request_path} = conn, opts) do
+    request_id_header = Keyword.get(opts, :request_id_header, "x-request-id")
+    remote_addr = PlugUtils.get_client_ip(conn)
+    request_id =
+      case PlugUtils.get_request_id(conn, request_id_header) do
+        [{_, request_id}] -> request_id
+        [] -> nil
+      end
+
+    %HTTPContext{
+      method: method,
+      path: request_path,
+      request_id: request_id,
+      remote_addr: remote_addr
+    }
+    |> Timber.add_context()
+
+    conn
+  end
+end

--- a/lib/timber/integrations/session_context_plug.ex
+++ b/lib/timber/integrations/session_context_plug.ex
@@ -1,0 +1,106 @@
+defmodule Timber.Integrations.SessionContextPlug do
+  @moduledoc """
+  Automatically tracks the session in Plug-based frameworks like Phoenix
+  and adds it to the context
+
+  The session context plug is only useful if you have session storage already
+  setup. More information about this can be found in the documentation for the
+  specific framework you're using:
+
+    - [Phoenix](http://www.phoenixframework.org/docs/sessions)
+    - [Plug](https://hexdocs.pm/plug/Plug.Session.html)
+
+  If you have chosen to not use sessions for your application, it's best not
+  to use this plug. Using this plug without properly setting up a session store
+  can cause HTTP responses to fail.
+
+  ## Adding the Plug
+
+  `Timber.Integrations.SessionContextPlug` can be added to your plug pipeline using the
+  standard `Plug.Builder.plug/2` macro. Because it requires access to the session, it should
+  be listed _after_ setting up the session store. The session store will usually be set up
+  using a call to `plug Plug.Session`.
+  """
+
+  @session_id_key :_timber_session_id
+
+  alias Timber.Contexts.SessionContext
+
+  @doc """
+  Prepares the given options for use in a plug pipeline
+
+  When the `Plug.Builder.plug/2` macro is called, it will use this
+  function to prepare options. Any resulting options will be
+  passed on to the plug on every call. The options accepted
+  by this function are the same as defined by `call/2`.
+  """
+  @spec init(Plug.opts) :: Plug.opts
+  def init(opts) do
+    opts
+  end
+
+  @doc """
+  Adds the Request ID to the Timber context data
+  """
+  @spec call(Plug.Conn.t, Plug.opts) :: Plug.Conn.t
+  def call(conn, _opts) do
+    initialize_session_id(conn)
+  end
+
+  @spec initialize_session_id(Plug.Conn.t) :: Plug.Conn.t
+  # Attempts to retrieve or initialize the Timber session ID.
+  #
+  # Timber assigns a unique, 32 character ID to every session. Once assigned, Timber
+  # is able to retrieve it for the duration of the session, so even on subsequent
+  # requests, the session ID remains the same.
+  #
+  # The session ID is then added to the Timber context as a side-effect. This prevents
+  # it being added if sessions are not being used.
+  #
+  # In order to retrieve the session, the session plug must already have been
+  # defined. If it hasn't been, fetching the session will cause an `ArgumentError`
+  # exception to be raised. In this case, the exception is rescued and the
+  #
+  defp initialize_session_id(conn) do
+    # We make sure the session has been fetched and loaded onto the conn. This call has
+    # the chance to raise if Plug doesn't have an adapter for sessions. If that's the
+    # case, the exception is rescued in the `rescue` section below.
+    session_conn = Plug.Conn.fetch_session(conn)
+    # Now that we've confirmed a session is loaded, we try to retrieve the session ID
+    # from Timber's custom session key. If this doesn't exist, we generate one.
+    #
+    # We make sure to put the session_id on the session at the end of this function,
+    # so we don't concern ourselves with that here.
+    session_id =
+      case Plug.Conn.get_session(session_conn, @session_id_key) do
+        nil ->
+          generate_session_id()
+        id ->
+          id
+      end
+
+    # We set up the session context and assign it to the Timber context here.
+    # This is the safest place to do it, since we've confirmed that the session is
+    # being used and a session ID has been generated. This is a side-effect, and we
+    # don't return anything about it to the caller function.
+    %SessionContext{id: session_id}
+    |> Timber.add_context()
+
+    # We ensure that we set the session_id on the session here, regardless of whether
+    # it was set before. This change is idempotent if it was already present.
+    Plug.Conn.put_session(session_conn, @session_id_key, session_id)
+  rescue
+    ArgumentError ->
+      # If no session Plug has been defined, the call to `Plug.Conn.fetch_session/1`
+      # will raise an ArgumentError. In this case, we return the original conn
+      # from the function parameters
+      conn
+  end
+
+  defp generate_session_id do
+    32
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 32)
+  end
+end

--- a/test/lib/timber/integrations/context_plug_test.exs
+++ b/test/lib/timber/integrations/context_plug_test.exs
@@ -1,7 +1,3 @@
 defmodule Timber.Integrations.ContextPlugTest do
   use Timber.TestCase
-
-  describe "Timber.Integrations.ContextPlug.new/4" do
-
-  end
 end

--- a/test/lib/timber/integrations/http_context_plug_test.exs
+++ b/test/lib/timber/integrations/http_context_plug_test.exs
@@ -1,0 +1,80 @@
+defmodule Timber.Integrations.HTTPContextPlugTest do
+  use Timber.TestCase
+
+  alias Timber.Integrations.HTTPContextPlug
+
+  setup do
+    conn = Plug.Test.conn(:get, "/")
+
+    {:ok, conn: conn}
+  end
+
+  describe "Timber.Integrations.HTTPContextPlug.call/2" do
+    test "captures HTTP method" do
+      conn = Plug.Test.conn(:delete, "/")
+
+      HTTPContextPlug.call(conn, [])
+
+      context = get_request_context()
+
+      assert context.method == "DELETE"
+    end
+
+    test "captures HTTP path" do
+      conn = Plug.Test.conn(:get, "/articles/1234")
+
+      HTTPContextPlug.call(conn, [])
+
+      context = get_request_context()
+
+      assert context.path == "/articles/1234"
+    end
+
+    test "captures remote address", %{conn: conn} do
+      conn = %Plug.Conn{ conn | remote_ip: {127, 0, 0, 1} }
+
+      HTTPContextPlug.call(conn, [])
+
+      context = get_request_context()
+
+      assert context.remote_addr == "127.0.0.1"
+    end
+
+    test "captures X-Request-ID header", %{conn: conn} do
+      request_id = "abcdefg"
+
+      conn = Plug.Conn.put_req_header(conn, "x-request-id", request_id)
+
+      HTTPContextPlug.call(conn, [])
+
+      context = get_request_context()
+
+      context_request_id = context.request_id
+
+      assert context_request_id == request_id
+    end
+
+    test "captures request ID from custom header", %{conn: conn} do
+      request_id_header = "x-timbertrace-id"
+      request_id = "abcdefg"
+
+      conn = Plug.Conn.put_req_header(conn, request_id_header, request_id)
+
+      HTTPContextPlug.call(conn, [request_id_header: request_id_header])
+
+      context = get_request_context()
+
+      context_request_id = context.request_id
+
+      assert context_request_id == request_id
+    end
+  end
+
+  def get_request_context() do
+    metadata = Logger.metadata()
+
+    metadata
+    |> Keyword.get(:timber_context)
+    |> Map.get(:http)
+  end
+end

--- a/test/lib/timber/integrations/session_context_plug_test.exs
+++ b/test/lib/timber/integrations/session_context_plug_test.exs
@@ -1,0 +1,51 @@
+defmodule TImber.Integrations.SessionContextPlugTest do
+  use Timber.TestCase
+
+  alias Timber.Integrations.SessionContextPlug
+
+  setup do
+    conn =
+      :get
+      |> Plug.Test.conn("/")
+      |> Plug.Test.init_test_session(%{})
+
+    {:ok, conn: conn}
+  end
+
+  describe "Timber.Integrations.SessionContextPlug.call/2" do
+    test "retrieves an existing Timber session ID from the session", %{conn: conn} do
+      timber_session_id = "timber"
+
+      conn = Plug.Test.init_test_session(conn, %{:_timber_session_id => timber_session_id})
+
+      conn = SessionContextPlug.call(conn, [])
+
+      conn_session_id = Plug.Conn.get_session(conn, :_timber_session_id)
+
+      context_session_id = get_session_context_id()
+
+      assert conn_session_id == timber_session_id
+      assert context_session_id == timber_session_id
+    end
+
+    test "sets a new Timber session ID if one does not exist", %{conn: conn} do
+      conn = SessionContextPlug.call(conn, [])
+
+      conn_session_id = Plug.Conn.get_session(conn, :_timber_session_id)
+
+      context_session_id = get_session_context_id()
+
+      refute is_nil(conn_session_id)
+      refute is_nil(context_session_id)
+    end
+  end
+
+  def get_session_context_id() do
+    metadata = Logger.metadata()
+
+    metadata
+    |> Keyword.get(:timber_context)
+    |> Map.get(:session)
+    |> Map.get(:id)
+  end
+end

--- a/test/support/installer/fake_file_contents.ex
+++ b/test/support/installer/fake_file_contents.ex
@@ -203,7 +203,8 @@ defmodule Timber.Installer.FakeFileContents do
         signing_salt: "abfd232"
 
       # Add Timber plugs for capturing HTTP context and events
-      plug Timber.Integrations.ContextPlug
+      plug Timber.Integrations.SessionContextPlug
+      plug Timber.Integrations.HTTPContextPlug
       plug Timber.Integrations.EventPlug
 
       plug TimberElixir.Router


### PR DESCRIPTION
This introduces the SessionContextPlug and HTTPContextPlug which replace the monolithic ContextPlug. The HTTPContextPlug captures the HTTPContext and the SessionContextPlug captures the SessionContext. This is advantageous for users who do not have a session store set up; those users encounter a raise during the Plug response phase that happens outside the package. These users can now remove the SessionContextPlug but retain the HTTPContextPlug functionality.

The existing ContextPlug module now calls out to both SessionContextPlug and HTTPContextPlug to maintain compatability. That module will be removed in version 3.0 of the package and beyond.

Closes #155