### PR TITLE
Enforce new byte limits

### DIFF
--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -1,5 +1,6 @@
 defmodule Timber.Config do
   @application :timber
+  @default_http_body_max_bytes 2048
 
   @doc """
   Your Timber application API key. This can be obtained after you create your
@@ -59,19 +60,17 @@ defmodule Timber.Config do
   def header_keys_to_sanitize, do: Application.get_env(@application, :header_keys_to_sanitize, [])
 
   @doc """
-  Configuration for the `:body` size limit in the `Timber.Events.HTTP*` events.
-  Bodies that exceed this limit will be truncated to this limit.
-
-  Please take care with this value, increasing it too high can mean very large
-  payloads and very high outgoing network activity.
+  Configuration for the `:body` byte size limit in the `Timber.Events.HTTP*` events.
+  Bodies that exceed this limit will be truncated to this byte limit. The default is
+  `2048` with a maximum allowed value of `8192`.
 
   # Example
 
   ```elixir
-  config :timber, :http_body_size_limit, 5000
+  config :timber, :http_body_size_limit, 2048
   ```
   """
-  def http_body_size_limit, do: Application.get_env(@application, :http_body_size_limit, 2000)
+  def http_body_size_limit, do: Application.get_env(@application, :http_body_size_limit, @default_http_body_max_bytes)
 
   @doc """
   Alternate URL for delivering logs. This is helpful if you want to use a proxy,

--- a/lib/timber/events/controller_call_event.ex
+++ b/lib/timber/events/controller_call_event.ex
@@ -18,7 +18,7 @@ defmodule Timber.Events.ControllerCallEvent do
     :pipelines
   ]
 
-  @params_json_limit 5_000
+  @params_json_max_bytes 8_192
 
   @doc """
   Builds a new struct taking care to:
@@ -32,7 +32,7 @@ defmodule Timber.Events.ControllerCallEvent do
       if params && params != %{} do
         params
         |> Timber.Utils.JSON.encode!()
-        |> Timber.Utils.Logger.truncate(@params_json_limit)
+        |> Timber.Utils.Logger.truncate_bytes(@params_json_max_bytes)
         |> to_string()
       else
         nil

--- a/lib/timber/events/exception_event.ex
+++ b/lib/timber/events/exception_event.ex
@@ -29,11 +29,11 @@ defmodule Timber.Events.ExceptionEvent do
   @enforce_keys [:backtrace, :name, :message]
   defstruct [:backtrace, :name, :message]
 
-  @app_name_limit 255
-  @file_limit 1_000
-  @function_limit 255
-  @message_limit 10_000
-  @name_limit 255
+  @app_name_byte_limit 256
+  @file_byte_limit 1_024
+  @function_byte_limit 256
+  @message_byte_limit 8_192
+  @name_byte_limit 256
 
   @doc """
   Builds a new struct taking care to normalize data into a valid state. This should
@@ -50,12 +50,12 @@ defmodule Timber.Events.ExceptionEvent do
       {:ok, {name, message, backtrace}} when is_binary(name) and length(backtrace) > 0 ->
         name =
           name
-          |> Timber.Utils.Logger.truncate(@name_limit)
+          |> Timber.Utils.Logger.truncate_bytes(@name_byte_limit)
           |> to_string()
 
         message =
           message
-          |> Timber.Utils.Logger.truncate(@message_limit)
+          |> Timber.Utils.Logger.truncate_bytes(@message_byte_limit)
           |> to_string()
 
         {:ok, %__MODULE__{name: name, message: message, backtrace: backtrace}}
@@ -93,19 +93,19 @@ defmodule Timber.Events.ExceptionEvent do
     do
       app_name =
         app_name
-        |> Timber.Utils.Logger.truncate(@app_name_limit)
+        |> Timber.Utils.Logger.truncate_bytes(@app_name_byte_limit)
         |> to_string()
 
       function =
         function
         |> String.trim()
-        |> Timber.Utils.Logger.truncate(@function_limit)
+        |> Timber.Utils.Logger.truncate_bytes(@function_byte_limit)
         |> to_string()
 
       file =
         file
         |> String.trim()
-        |> Timber.Utils.Logger.truncate(@file_limit)
+        |> Timber.Utils.Logger.truncate_bytes(@file_byte_limit)
         |> to_string()
 
       if function != "" && file != "" do

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -39,7 +39,7 @@ defmodule Timber.LogEntry do
     time_ms: nil | float
   }
 
-  @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/v2.1.0/schema.json"
+  @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/v2.1.1/schema.json"
 
   @doc """
   Creates a new `LogEntry` struct

--- a/lib/timber/utils/http_events.ex
+++ b/lib/timber/utils/http_events.ex
@@ -5,6 +5,7 @@ defmodule Timber.Utils.HTTPEvents do
 
   @multi_header_delimiter ","
   @header_keys_to_sanitize ["authorization", "x-amz-security-token"]
+  @header_value_byte_limit 256
   @sanitized_value "[sanitized]"
 
   def format_time_ms(time_ms) when is_integer(time_ms),
@@ -61,7 +62,7 @@ defmodule Timber.Utils.HTTPEvents do
   def normalize_body(body) when is_binary(body) do
     limit = Config.http_body_size_limit()
     body
-    |> Timber.Utils.Logger.truncate(limit)
+    |> Timber.Utils.Logger.truncate_bytes(limit)
     |> to_string()
   end
 
@@ -96,7 +97,7 @@ defmodule Timber.Utils.HTTPEvents do
   defp normalize_header({name, value}) do
     value =
       value
-      |> Timber.Utils.Logger.truncate(255)
+      |> Timber.Utils.Logger.truncate_bytes(@header_value_byte_limit)
       |> to_string()
 
     {String.downcase(name), value}

--- a/lib/timber/utils/logger.ex
+++ b/lib/timber/utils/logger.ex
@@ -26,9 +26,9 @@ defmodule Timber.Utils.Logger do
   Truncate a binary to the given length, taking into account the " (truncated)"
   suffix that the Logger.Utils.truncate/1 method appends.
   """
-  @spec truncate(IO.chardata, pos_integer) :: IO.chardata
-  def truncate(chardata, limit) do
-    adjusted_limit = limit - 15 # takes into account the " (truncated)" string that the below function appends
-    Logger.Utils.truncate(chardata, adjusted_limit)
+  @spec truncate_bytes(IO.chardata, pos_integer) :: IO.chardata
+  def truncate_bytes(chardata, byte_limit) do
+    adjusted_byte_limit = byte_limit - 15 # takes into account the " (truncated)" string that the below function appends
+    Logger.Utils.truncate(chardata, adjusted_byte_limit)
   end
 end

--- a/test/lib/timber/logger_backends/http_test.exs
+++ b/test/lib/timber/logger_backends/http_test.exs
@@ -48,7 +48,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
 
   describe "Timber.LoggerBackends.HTTP.handle_event/2" do
     test ":flush message fails silently without an API key", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
       {:ok, :ok, state} = HTTP.handle_call({:configure, [api_key: nil]}, state)
       {:ok, state} = HTTP.handle_event(entry, state)
@@ -57,7 +57,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
     end
 
     test ":flush message issues a request", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
       {:ok, state} = HTTP.handle_event(entry, state)
       HTTP.handle_event(:flush, state)
@@ -77,7 +77,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
     end
 
     test ":flush message issues a request with chardata", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
       {:ok, state} = HTTP.handle_event(entry, state)
       HTTP.handle_event(:flush, state)
@@ -91,7 +91,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
     end
 
     test "failure of the http client will not cause the :flush message to raise", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
       expected_method = :post
       expected_url = "https://logs.timber.io/frames"
@@ -110,7 +110,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
     end
 
     test "message event buffers the message if the buffer is not full", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
 
       {:ok, new_state} = HTTP.handle_event(entry, state)
       assert new_state.buffer == [event_entry_to_log_entry(entry)]
@@ -119,7 +119,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
     end
 
     test "flushes if the buffer is full", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
       state = %{state | max_buffer_size: 1}
       HTTP.handle_event(entry, state)
       calls = FakeHTTPClient.get_async_request_calls()
@@ -129,7 +129,7 @@ defmodule Timber.LoggerBackends.HTTPTest do
 
   describe "Timber.LoggerBackends.HTTP.handle_info/2" do
     test "handles the outlet properly", %{state: state} do
-      entry = {:info, self, {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
+      entry = {:info, self(), {Logger, "message", time(), [event: %{type: :type, data: %{}}]}}
       {:ok, state} = HTTP.handle_event(entry, state)
       {:ok, new_state} = HTTP.handle_info(:outlet, state)
       calls = FakeHTTPClient.get_async_request_calls()

--- a/test/lib/timber/utils/http_event_test.exs
+++ b/test/lib/timber/utils/http_event_test.exs
@@ -25,8 +25,8 @@ defmodule Timber.Utils.HTTPEventsTest do
     end
 
     test "exceeds length" do
-      body = String.duplicate("a", 20001)
-      assert HTTPEvents.normalize_body(body) == "#{String.duplicate("a", 1985)} (truncated)"
+      body = String.duplicate("a", 2049)
+      assert HTTPEvents.normalize_body(body) == "#{String.duplicate("a", 2033)} (truncated)"
     end
   end
 


### PR DESCRIPTION
This updates the byte limits to be inline with the new limits set in the [v2.1.1 of our JSON schema](https://github.com/timberio/log-event-json-schema/releases/tag/v2.1.1)