### PR TITLE
Add support for the new `:meta` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Logger.info("Payment rejected", meta: %{customer_id: "abcd1234", amount: 100, cu
 
 ---
 
+</p></details>
+
 <details><summary><strong>Custom events</strong></summary><p>
 
 Events are just defined structures with a namespace. They are more formal and avoid type collisions.

--- a/README.md
+++ b/README.md
@@ -209,28 +209,6 @@ Logger.info("Received parameters", meta: %{parameters: %{key: "val"}})
 
 </p></details>
 
-<details><summary><strong>How is Timber different?</strong></summary><p>
-
-1. **It's just _better_ logging**. Nothing beats well structured raw data. And that's exactly
-   what Timber aims to provide. There are no agents, special APIs, or proprietary data
-   sets that you can't access.
-2. **Improved log data quality.** Instead of relying on parsing alone, Timber ships libraries that
-   structure and augment your logs from _within_ your application. Improving your log data at the
-   source.
-3. **Human readability.** Timber _augments_ your logs without sacrificing human readability. For
-   example: `log message @metadata {...}`. And when you view your logs in the
-   [Timber console](https://app.timber.io), you'll see the human friendly messages
-   with the ability to view the associated metadata.
-4. **Long retention**. Logging is notoriously expensive with low retention. Timber
-   offers _6 months_ of retention by default with sane prices.
-5. **Normalized schema.** Have multiple apps? All of Timber's libraries adhere to our
-   [JSON schema](https://github.com/timberio/log-event-json-schema). This means queries, alerts,
-   and graphs for your ruby app can also be applied to your elixir app (for example).
-
----
-
-</p></details>
-
 ---
 
 <p align="center" style="background: #221f40;">

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Logger.info("Payment rejected", meta: %{customer_id: "abcd1234", amount: 100, cu
 * In the [Timber console](https://app.timber.io) use the query: `customer_id:abcd1234` or `amount:>100`.
 * **Warning:** metadata keys must use consistent types as the values. If `customer_id` key was
   sent an integer, it would not be indexed because it was first sent a string. See the
-  "Custom events" example if you'd like to avoid this.
+  "Custom events" example below if you'd like to avoid this.
   See [when to use metadata or events](#jibber-jabber).
 
 ---

--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ Logger.info("Received parameters", meta: %{parameters: %{key: "val"}})
 
 ---
 
-</p>
-
+</p></details>
 
 <details><summary><strong>How is Timber different?</strong></summary><p>
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For a complete overview, see the [Timber for Elixir docs](https://timber.io/docs
 
 ## Usage
 
-<details><summary><strong>Basic logging</strong></summary><p>
+<details><summary><strong>Basic text logging</strong></summary><p>
 
 No special API, Timber works directly with `Logger`:
 
@@ -83,9 +83,28 @@ Logger.info("My log message")
 
 </p></details>
 
+<details><summary><strong>Structured logging (metadata)</strong></summary><p>
+
+Simply use Elixir's native Logger metadata:
+
+```elixir
+Logger.info("Payment rejected", meta: %{customer_id: "abcd1234", amount: 100, currency: "USD"})
+
+# => My log message @metadata {"level": "info", "meta": {"customer_id": "abcd1234", "amount": 100}}
+```
+
+* In the [Timber console](https://app.timber.io) use the query: `customer_id:abcd1234` or `amount:>100`.
+* **Warning:** metadata keys must use consistent types as the values. If `customer_id` key was
+  sent an integer, it would not be indexed because it was first sent a string. See the
+  "Custom events" example if you'd like to avoid this.
+  See [when to use metadata or events](#jibber-jabber).
+
+---
+
 <details><summary><strong>Custom events</strong></summary><p>
 
-Custom events allow you to extend beyond events already defined in
+Events are just defined structures with a namespace. They are more formal and avoid type collisions.
+Custom events, specifically, allow you to extend beyond events already defined in
 the [`Timber.Events`](lib/timber/events) namespace.
 
 ```elixir
@@ -95,9 +114,8 @@ Logger.info("Payment rejected", event: %{payment_rejected: event_data})
 # => Payment rejected @metadata {"level": "warn", "event": {"payment_rejected": {"customer_id": "xiaus1934", "amount": 100, "reason": "Card expired"}}, "context": {...}}
 ```
 
-* Notice the `:payment_rejected` root key. Timber will classify this event as such.
 * In the [Timber console](https://app.timber.io) use the query: `type:payment_rejected` or `payment_rejected.amount:>100`.
-
+* See [when to use metadata or events](#jibber-jabber)
 
 ---
 
@@ -154,6 +172,41 @@ In fact, traditional log statements for non-meaningful events, debug statements,
 encouraged. In cases where the data is meaningful, consider [logging a custom event](#usage).
 
 </p></details>
+
+<details><summary><strong>When to use metadata or events?</strong></summary><p>
+
+At it's basic level, both metadata and eventa serve the same purpose: they add structured
+data to your logs. And anyone that's implemented structured logging know's this can quickly get
+out of hand. This is why we created events. Here's how we recommend using them:
+
+1. Use `events` when the log cleanly maps to an event that is core to your business. Something
+   that you'd like to alert on, graph, or use in a meaningful way.
+2. Use metadata for debugging purposes; when you simply want additional insight without
+   polluting the message.
+
+### Example: Logging that a payment was rejected
+
+This is clearly an event that is meaningful to your business. You'll probably want to alert and
+graph this data. So let's log it as an official event:
+
+```elixir
+event_data = %{customer_id: "xiaus1934", amount: 1900, currency: "USD"}
+Logger.info("Payment rejected", event: %{payment_rejected: event_data})
+```
+
+### Example: Gaining additional insight before an error occurs
+
+This is not an event, but it is helpful data. Let's add it as metadata so that we don't pollute
+the message, ensuring the log is reable:
+
+```elixir
+Logger.info("Received parameters", meta: %{parameters: %{key: "val"}})
+```
+
+---
+
+</p>
+
 
 <details><summary><strong>How is Timber different?</strong></summary><p>
 

--- a/lib/timber/current_context.ex
+++ b/lib/timber/current_context.ex
@@ -13,12 +13,12 @@ defmodule Timber.CurrentContext do
   @spec load :: Context.t
   def load do
     Elixir.Logger.metadata()
-    |> extract()
+    |> extract_from_metadata()
   end
 
   @doc false
-  @spec extract(Keyword.t) :: Context.t
-  def extract(metadata) do
+  @spec extract_from_metadata(Keyword.t) :: Context.t
+  def extract_from_metadata(metadata) do
     Keyword.get(metadata, :timber_context, Context.new())
   end
 

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -17,6 +17,18 @@ defmodule Timber.Event do
     Events.TemplateRenderEvent
 
   @doc false
+  @spec extract_from_metadata(Keyword.t) :: nil | t
+  def extract_from_metadata(metadata) do
+    Keyword.get(metadata, Timber.Config.event_key(), nil)
+  end
+
+  @doc false
+  @spec to_metadata(Timber.Event.t) :: Keyword.t
+  def to_metadata(event) do
+    Keyword.put([], Timber.Config.event_key(), event)
+  end
+
+  @doc false
   @spec to_api_map(t) :: map
   def to_api_map(%Events.CustomEvent{type: type} = event) when is_binary(type) do
     atom_type = String.to_atom(type)

--- a/lib/timber/integrations/ecto_logger.ex
+++ b/lib/timber/integrations/ecto_logger.ex
@@ -47,6 +47,7 @@ defmodule Timber.Integrations.EctoLogger do
 
   require Logger
 
+  alias Timber.Event
   alias Timber.Events.SQLQueryEvent
 
   @doc """
@@ -80,7 +81,7 @@ defmodule Timber.Integrations.EctoLogger do
         }
 
         message = SQLQueryEvent.message(event)
-        metadata = Timber.Utils.Logger.event_to_metadata(event)
+        metadata = Event.to_metadata(event)
 
         Logger.log(level, message, metadata)
 

--- a/lib/timber/integrations/event_plug.ex
+++ b/lib/timber/integrations/event_plug.ex
@@ -68,7 +68,9 @@ defmodule Timber.Integrations.EventPlug do
 
   require Logger
 
-  alias Timber.Events.{HTTPServerRequestEvent, HTTPServerResponseEvent}
+  alias Timber.Event
+  alias Timber.Events.HTTPServerRequestEvent
+  alias Timber.Events.HTTPServerResponseEvent
   alias Timber.Timer
   alias Timber.Utils.Plug, as: PlugUtils
 
@@ -118,7 +120,7 @@ defmodule Timber.Integrations.EventPlug do
     )
 
     message = HTTPServerRequestEvent.message(event)
-    metadata = Timber.Utils.Logger.event_to_metadata(event)
+    metadata = Event.to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 
@@ -155,7 +157,7 @@ defmodule Timber.Integrations.EventPlug do
     )
 
     message = HTTPServerResponseEvent.message(event)
-    metadata = Timber.Utils.Logger.event_to_metadata(event)
+    metadata = Event.to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -71,6 +71,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
 
   require Logger
 
+  alias Timber.Event
   alias Timber.Events.ControllerCallEvent
   alias Timber.Events.TemplateRenderEvent
 
@@ -97,7 +98,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     )
 
     message = ControllerCallEvent.message(event)
-    metadata = Timber.Utils.Logger.event_to_metadata(event)
+    metadata = Event.to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 
@@ -130,7 +131,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     }
 
     message = TemplateRenderEvent.message(event)
-    metadata = Timber.Utils.Logger.event_to_metadata(event)
+    metadata = Event.to_metadata(event)
 
     Logger.log(log_level, message, metadata)
 

--- a/lib/timber/utils/logger.ex
+++ b/lib/timber/utils/logger.ex
@@ -2,27 +2,6 @@ defmodule Timber.Utils.Logger do
   @moduledoc false
 
   @doc """
-  Convenience function for using the metadata logger key specified in the configuration.
-  This is equivalent to:
-
-  ## Examples
-
-  ```elixir
-  metadata = Timber.Utils.Logger.event_to_metadata(event)
-  Logger.info("my message", metadata)
-  ```
-  """
-  @spec event_to_metadata(Timber.Event.t) :: Keyword.t
-  def event_to_metadata(event) do
-    Keyword.put([], Timber.Config.event_key(), event)
-  end
-
-  @spec get_event_from_metadata(Keyword.t) :: nil | Timber.Event.t
-  def get_event_from_metadata(metadata) do
-    Keyword.get(metadata, Timber.Config.event_key(), nil)
-  end
-
-  @doc """
   Truncate a binary to the given length, taking into account the " (truncated)"
   suffix that the Logger.Utils.truncate/1 method appends.
   """

--- a/test/lib/timber/log_entry_test.exs
+++ b/test/lib/timber/log_entry_test.exs
@@ -60,7 +60,7 @@ defmodule Timber.Events.LogEntryTest do
     test "encodes logfmt properly" do
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{a: 1}}])
       result = LogEntry.to_iodata!(entry, :logfmt)
-      assert result == [[10, 9, "Context: ", ["system.pid", 61, "#{pid()}", 32, "system.hostname", 61, "#{hostname()}"]], [10, 9, "Event: ", ["custom.type.a", 61, "1"]]]
+      assert result == [[10, 9, "Context: ", ["system.pid", 61, "#{pid()}", 32, "system.hostname", 61, "#{hostname()}"]], [10, 9, "Event: ", ["custom.type.a", 61, "1"]], []]
     end
   end
 


### PR DESCRIPTION
This adds support for the new `:meta` key when logging structured data. Here's the new explanation in the readme that explains when to use each:

---

At it's basic level, both metadata and eventa serve the same purpose: they add structured
data to your logs. And anyone that's implemented structured logging know's this can quickly get
out of hand. This is why we created events. Here's how we recommend using them:

1. Use `events` when the log cleanly maps to an event that is core to your business. Something
   that you'd like to alert on, graph, or use in a meaningful way.
2. Use metadata for debugging purposes; when you simply want additional insight without
   polluting the message.

### Example: Logging that a payment was rejected

This is clearly an event that is meaningful to your business. You'll probably want to alert and
graph this data. So let's log it as an official event:

```elixir
event_data = %{customer_id: "xiaus1934", amount: 1900, currency: "USD"}
Logger.info("Payment rejected", event: %{payment_rejected: event_data})
```

### Example: Gaining additional insight before an error occurs

This is not an event, but it is helpful data. Let's add it as metadata so that we don't pollute
the message, ensuring the log is reable:

```elixir
Logger.info("Received parameters", meta: %{parameters: %{key: "val"}})
```