### PR TITLE
Add option to use nanosecond timestamps

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,8 @@ config :logger, :console,
   metadata: [:timber_context, :event, :application, :file, :function, :line, :module, :meta]
 
 config :timber,
-  header_keys_to_sanitize: ["sensitive-key"]
+  header_keys_to_sanitize: ["sensitive-key"],
+  nanosecond_timestamps: false
 
 config :timber, Timber.Formatter,
   format: :logfmt

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -99,6 +99,23 @@ defmodule Timber.Config do
   def json_encoder, do: Application.get_env(@application, :json_encoder, &Poison.encode_to_iodata!/1)
 
   @doc """
+  Unfortunately the `Elixir.Logger` produces timestamps with microsecond prevision.
+  In a high volume system, this can produce logs with matching timestamps, making it
+  impossible to preseve the order of the logs. By enabling this, Timber will discard
+  the default `Elixir.Logger` timestamps and use it's own with nanosecond precision.
+
+  # Example
+
+  ```elixir
+  config :timber, :nanosecond_timestamps, true
+  ```
+  """
+  @spec use_nanosecond_timestamps? :: boolean
+  def use_nanosecond_timestamps? do
+    Application.get_env(@application, :nanosecond_timestamps, true)
+  end
+
+  @doc """
   Specify the log level that phoenix log lines write to. Such as template renders.
 
   # Example
@@ -111,10 +128,4 @@ defmodule Timber.Config do
   def phoenix_instrumentation_level(default) do
     Application.get_env(@application, :instrumentation_level, default)
   end
-
-  @doc """
-  Gets the transport specificed in the :timber configuration. The default is
-  `Timber.Transports.IODevice`.
-  """
-  def transport, do: Application.get_env(@application, :transport, Timber.Transports.IODevice)
 end

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -14,6 +14,7 @@ defmodule Timber.LogEntry do
   See the main `Timber` module for more information.
   """
 
+  alias Timber.Config
   alias Timber.Context
   alias Timber.Contexts.RuntimeContext
   alias Timber.Contexts.SystemContext
@@ -54,10 +55,15 @@ defmodule Timber.LogEntry do
   """
   @spec new(LoggerBackend.timestamp, Logger.level, Logger.message, Keyword.t) :: t
   def new(timestamp, level, message, metadata) do
-    io_timestamp =
-      timestamp
-      |> UtilsTimestamp.format_timestamp()
-      |> IO.chardata_to_string()
+    dt_iso8601 =
+      if Config.use_nanosecond_timestamps? do
+        DateTime.utc_now()
+        |> DateTime.to_iso8601()
+      else
+        timestamp
+        |> UtilsTimestamp.format_timestamp()
+        |> IO.chardata_to_string()
+      end
 
     context =
       metadata
@@ -71,7 +77,7 @@ defmodule Timber.LogEntry do
     time_ms = Keyword.get(metadata, :time_ms)
 
     %__MODULE__{
-      dt: io_timestamp,
+      dt: dt_iso8601,
       level: level,
       message: message,
       context: context,

--- a/lib/timber/logger_backends/http.ex
+++ b/lib/timber/logger_backends/http.ex
@@ -227,7 +227,6 @@ defmodule Timber.LoggerBackends.HTTP do
   @spec output_event(timestamp, level, IO.chardata, Keyword.t, t) :: t
   defp output_event(ts, level, message, metadata, state) do
     log_entry = LogEntry.new(ts, level, message, metadata)
-
     state = write_buffer(log_entry, state)
 
     if buffer_full?(state) do

--- a/mix.exs
+++ b/mix.exs
@@ -69,9 +69,7 @@ defmodule Timber.Mixfile do
 
   # The environment to be configured by default
   defp env() do
-    [
-      transport: Timber.Transports.IODevice,
-    ]
+    []
   end
 
   # Compiler paths switched on the Mix environment


### PR DESCRIPTION
This adds a new configuration option to use nanosecond timestamp instead of the default `Elixir.Logger` timestamps that are limited to microseconds.