### PR TITLE
Add ExAWS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,20 @@ logs and structures AWS HTTP communication
 [`http_request`](https://timber.io/docs/elixir/events-and-context/http-request-event/) and
 [`http_response`](https://timber.io/docs/elixir/events-and-context/http-response-event/) events.
 
+### Installation
+
+```elixir
+config :ex_aws,
+  http_client: Timber.Integrations.ExAwsHTTPClient
+```
+
+For more details, please see the
+[`Timber.Integrations.ExAwsHTTPClient` docs](https://hexdocs.pm/timber/Timber.Integrations.ExAwsHTTPClient.html#content).
+
+---
 
 </p></details>
+
 
 ## Jibber-Jabber
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,82 @@ everything from our search syntax to alerting and graphin.
 
 </p></details>
 
+
+## Integrations
+
+<details><summary><strong>Phoenix</strong></summary><p>
+
+The [`Phoenix` integration](https://hexdocs.pm/timber/Timber.Integrations.PhoenixInstrumenter.html#content)
+structures your existing `Phoenix` logs into
+[`controller_call`](https://timber.io/docs/elixir/events-and-context/controller-call-event/) and
+[`template_render`](https://timber.io/docs/elixir/events-and-context/template-render-event/) events.
+
+Pro-tip: this integration captures the parameters sent to your controller, making it easy to
+debug issues by understanding exactly which data was sent to your controller.
+
+
+### Installation
+
+To install this integration, please run the `mix timber.install` command as noted in the
+[installation section](#installation). For manual installation, please see the
+[`Timber.Integrations.PhoenixInstrumenter` docs](https://hexdocs.pm/timber/Timber.Integrations.PhoenixInstrumenter.html#content).
+
+---
+
+</p></details>
+
+<details><summary><strong>Ecto</strong></summary><p>
+
+The [`Ecto` integration](https://hexdocs.pm/timber/Timber.Integrations.EctoLogger.html#content)
+structures your existing `Ecto` logs into structured
+[`sql_query`](https://timber.io/docs/elixir/events-and-context/sql-query-event/) events.
+
+Pro-tip: this integration captures SQL query times, making it easy to visualize SQL query
+performance and find slow queries.
+
+### Installation
+
+To install this integration, please run the `mix timber.install` command as noted in the
+[installation section](#installation). For manual installation, please see the
+[`Timber.Integrations.EctoLogger` docs](https://hexdocs.pm/timber/Timber.Integrations.EctoLogger.html#content).
+
+---
+
+</p></details>
+
+<details><summary><strong>Plug</strong></summary><p>
+
+The [`Plug` integration](https://hexdocs.pm/timber/Timber.Integrations.EctoLogger.html#content)
+structures your existing `Plug` logs into
+[`http_request`](https://timber.io/docs/elixir/events-and-context/http-request-event/) and
+[`http_response`](https://timber.io/docs/elixir/events-and-context/http-response-event/) events.
+
+Pro-tip: this integration captures HTTP response codes and times, making it easy to visualize
+the performance of your application.
+
+### Installation
+
+To install this integration, please run the `mix timber.install` command as noted in the
+[installation section](#installation). For manual installation, please see the
+[`Timber.Integrations.EventPlug`](https://hexdocs.pm/timber/Timber.Integrations.EventPlug.html#content),
+[`Timber.Integrations.HTTPContextPlug`](https://hexdocs.pm/timber/Timber.Integrations.HTTPContextPlug.html#content),
+and [`Timber.Integrations.SessionContextPlug`](https://hexdocs.pm/timber/Timber.Integrations.SessionContextPlug.html#content)
+docs. We highly recommend using the installer!
+
+---
+
+</p></details>
+
+<details><summary><strong>ExAws</strong></summary><p>
+
+The [`ExAws` integration](https://hexdocs.pm/timber/Timber.Integrations.EctoLogger.html#content)
+logs and structures AWS HTTP communication
+[`http_request`](https://timber.io/docs/elixir/events-and-context/http-request-event/) and
+[`http_response`](https://timber.io/docs/elixir/events-and-context/http-response-event/) events.
+
+
+</p></details>
+
 ## Jibber-Jabber
 
 <details><summary><strong>Which log events does Timber structure for me?</strong></summary><p>

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ debug issues by understanding exactly which data was sent to your controller.
 ### Installation
 
 To install this integration, please run the `mix timber.install` command as noted in the
-[installation section](#installation). For manual installation, please see the
+[installation section](#installation).
+
+For manual installation, please see the
 [`Timber.Integrations.PhoenixInstrumenter` docs](https://hexdocs.pm/timber/Timber.Integrations.PhoenixInstrumenter.html#content).
 
 ---
@@ -201,7 +203,9 @@ performance and find slow queries.
 ### Installation
 
 To install this integration, please run the `mix timber.install` command as noted in the
-[installation section](#installation). For manual installation, please see the
+[installation section](#installation).
+
+For manual installation, please see the
 [`Timber.Integrations.EctoLogger` docs](https://hexdocs.pm/timber/Timber.Integrations.EctoLogger.html#content).
 
 ---
@@ -221,7 +225,9 @@ the performance of your application.
 ### Installation
 
 To install this integration, please run the `mix timber.install` command as noted in the
-[installation section](#installation). For manual installation, please see the
+[installation section](#installation).
+
+For manual installation, please see the
 [`Timber.Integrations.EventPlug`](https://hexdocs.pm/timber/Timber.Integrations.EventPlug.html#content),
 [`Timber.Integrations.HTTPContextPlug`](https://hexdocs.pm/timber/Timber.Integrations.HTTPContextPlug.html#content),
 and [`Timber.Integrations.SessionContextPlug`](https://hexdocs.pm/timber/Timber.Integrations.SessionContextPlug.html#content)

--- a/lib/timber/events/http_request_event.ex
+++ b/lib/timber/events/http_request_event.ex
@@ -44,6 +44,7 @@ defmodule Timber.Events.HTTPRequestEvent do
       |> Keyword.delete(:body) # Don't store the body for now. We store the params in the ControllerCallEvent. We can re-enable this upon request.
       |> Keyword.update(:headers, nil, fn headers -> UtilsHTTPEvents.normalize_headers(headers) end)
       |> Keyword.update(:method, nil, &UtilsHTTPEvents.normalize_method/1)
+      |> Keyword.update(:service_name, nil, &to_string/1)
       |> Keyword.merge(UtilsHTTPEvents.normalize_url(Keyword.get(opts, :url)))
       |> Keyword.delete(:url)
       |> Enum.filter(fn {_k,v} -> !(v in [nil, ""]) end)

--- a/lib/timber/events/http_response_event.ex
+++ b/lib/timber/events/http_response_event.ex
@@ -35,7 +35,7 @@ defmodule Timber.Events.HTTPResponseEvent do
   def new(opts) do
     opts =
       opts
-      |> Keyword.delete(:body) # Don't store the body for now. We store the params in the ControllerCallEvent. We can re-enable this upon request.
+      |> Keyword.update(:body, nil, fn body -> UtilsHTTPEvents.normalize_body(body) end)
       |> Keyword.update(:headers, nil, fn headers -> UtilsHTTPEvents.normalize_headers(headers) end)
       |> Keyword.update(:service_name, nil, &to_string/1)
       |> Enum.filter(fn {_k,v} -> !(v in [nil, ""]) end)

--- a/lib/timber/events/http_response_event.ex
+++ b/lib/timber/events/http_response_event.ex
@@ -37,6 +37,7 @@ defmodule Timber.Events.HTTPResponseEvent do
       opts
       |> Keyword.delete(:body) # Don't store the body for now. We store the params in the ControllerCallEvent. We can re-enable this upon request.
       |> Keyword.update(:headers, nil, fn headers -> UtilsHTTPEvents.normalize_headers(headers) end)
+      |> Keyword.update(:service_name, nil, &to_string/1)
       |> Enum.filter(fn {_k,v} -> !(v in [nil, ""]) end)
       |> UtilsHTTPEvents.move_headers_to_headers_json()
 
@@ -57,7 +58,7 @@ defmodule Timber.Events.HTTPResponseEvent do
       end
 
     message = if event.service_name,
-      do: [message, " from ", to_string(event.service_name)],
+      do: [message, " from ", event.service_name],
       else: message
 
     [message, " in ", UtilsHTTPEvents.format_time_ms(event.time_ms)]

--- a/lib/timber/integrations/event_plug.ex
+++ b/lib/timber/integrations/event_plug.ex
@@ -108,7 +108,9 @@ defmodule Timber.Integrations.EventPlug do
     query_string = conn.query_string
 
     event = HTTPRequestEvent.new(
-      body: conn.body_params, # the body is normalized and truncated if necessary
+      # Disabled for now since the body can be excessive and the params should be captured
+      # in the controller_call event.
+      # body: conn.body_params,
       direction: "incoming",
       headers: headers,
       host: host,
@@ -150,7 +152,6 @@ defmodule Timber.Integrations.EventPlug do
     request_id = request_id_from_header(request_id_header)
 
     event = HTTPResponseEvent.new(
-      body: conn.resp_body, # the body is normalized and truncated if necessary
       direction: "outgoing",
       headers: headers,
       request_id: request_id,

--- a/lib/timber/integrations/ex_aws_http_client.ex
+++ b/lib/timber/integrations/ex_aws_http_client.ex
@@ -1,0 +1,121 @@
+defmodule Timber.Integrations.ExAwsHTTPClient do
+  @moduledoc """
+  [ExAWS](https://github.com/CargoSense/ex_aws) is an excellent library for interfacing with the
+  AWS API. The Timber `ExAWSHTTPClient` adds structured logging to the HTTP requests being
+  sent to the AWS API. This gives you valuable insight into AWS communication from your application.
+  We use is internally at Timber.
+
+  **By default**, this library will only log destructive requests (`POST`, `PUT`, `DELETE`,
+  and `PATCH`). `GET` requests can be turned via configuration (see below).
+
+  ## Installation
+
+  ```elixir
+  config :ex_aws,
+    http_client: Timber.Integrations.ExAwsHTTPClient
+  ```
+
+  ## Configuration
+
+  ```elixir
+  config :timber, Timber.Integrations.ExAWSHTTPClient,
+    log_destructive_requests_only: true
+  ```
+
+  * `log_destructive_requests_only` - (default: `true`) Only log `POST`, `PUT`, `DELETE`,
+    and `PATCH` requests.
+  """
+
+  alias Timber.Events.HTTPRequestEvent
+  alias Timber.Events.HTTPResponseEvent
+
+  require Logger
+
+  # Set a timeout slightly over the general AWS timeout. This ensures that we receive
+  # the timeout event from AWS before we receive it internally, preventing orphaned requests.
+  @default_opts [recv_timeout: 62_000]
+  @destructive_methods [:patch, :post, :put, :delete]
+  @service_name :aws
+
+  def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
+    opts =
+      :ex_aws
+      |> Application.get_env(:hackney_opts, @default_opts)
+      |> Keyword.merge(http_opts)
+      |> Keyword.put(:with_body, true)
+
+    timer = Timber.start_timer()
+    should_log = should_log?(method, log_destructive_requests_only?())
+    log_request(should_log, method, url, body, headers)
+
+    case :hackney.request(method, url, headers, body, opts) do
+      {:ok, status, headers} ->
+        log_response(should_log, status, headers, timer)
+        {:ok, %{status_code: status, headers: headers}}
+
+      {:ok, status, headers, body} ->
+        log_response(should_log, status, headers, timer, body: body)
+        {:ok, %{status_code: status, headers: headers, body: body}}
+
+      {:error, reason} ->
+        # Errors are not logged because they should be handled. It is up
+        # to the caller to log these properly.
+        {:error, %{reason: reason}}
+    end
+  end
+
+  defp should_log?(method, true) when method in @destructive_methods,
+    do: true
+
+  defp should_log?(_method, _log_destructive_requests_only),
+    do: true
+
+  defp log_request(false, _method, _url, _body, _headers),
+    do: nil
+
+  defp log_request(true, method, url, body, headers) do
+    Logger.info fn ->
+      event =
+        HTTPRequestEvent.new(
+          direction: "outgoing",
+          method: method,
+          url: url,
+          body: body,
+          headers: headers,
+          service_name: @service_name
+        )
+      message = HTTPRequestEvent.message(event)
+      {message, event: event}
+    end
+  end
+
+  defp log_response(should_log, status, headers, timer, opts \\ [])
+
+  defp log_response(false, _status, _headers, _timer, _opts),
+    do: nil
+
+  defp log_response(true, status, headers, timer, opts) do
+    Logger.info fn ->
+      time_ms = Timber.duration_ms(timer)
+      body = Keyword.get(opts, :body)
+      event =
+        HTTPResponseEvent.new(
+          direction: "incoming",
+          body: body,
+          status: status,
+          headers: headers,
+          service_name: @service_name,
+          time_ms: time_ms
+        )
+      message = HTTPResponseEvent.message(event)
+      {message, event: event}
+    end
+  end
+
+  #
+  # Config
+  #
+
+  defp config, do: Elixir.Application.get_env(:timber, __MODULE__, [])
+  defp log_destructive_requests_only?, do: Keyword.get(config(), :log_destructive_requests_only, true) == true
+end

--- a/lib/timber/integrations/ex_aws_http_client.ex
+++ b/lib/timber/integrations/ex_aws_http_client.ex
@@ -118,5 +118,5 @@ defmodule Timber.Integrations.ExAwsHTTPClient do
   #
 
   defp config, do: Elixir.Application.get_env(:timber, __MODULE__, [])
-  defp only_log_methods, do: Keyword.get(config(), :only_log_methods, @only_log_methods_default) == true
+  defp only_log_methods, do: Keyword.get(config(), :only_log_methods, @only_log_methods_default)
 end

--- a/lib/timber/integrations/ex_aws_http_client.ex
+++ b/lib/timber/integrations/ex_aws_http_client.ex
@@ -35,7 +35,7 @@ defmodule Timber.Integrations.ExAwsHTTPClient do
   # the timeout event from AWS before we receive it internally, preventing orphaned requests.
   @default_opts [recv_timeout: 62_000]
   @destructive_methods [:patch, :post, :put, :delete]
-  @service_name :aws
+  @service_name "aws"
 
   def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
     opts =

--- a/lib/timber/integrations/ex_aws_http_client.ex
+++ b/lib/timber/integrations/ex_aws_http_client.ex
@@ -34,7 +34,7 @@ defmodule Timber.Integrations.ExAwsHTTPClient do
   # Set a timeout slightly over the general AWS timeout. This ensures that we receive
   # the timeout event from AWS before we receive it internally, preventing orphaned requests.
   @default_opts [recv_timeout: 62_000]
-  @non_idempotent_methods [:patch, :post, :put, :delete]
+  @only_log_methods_default [:patch, :post, :put, :delete]
   @service_name "aws"
 
   def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
@@ -118,5 +118,5 @@ defmodule Timber.Integrations.ExAwsHTTPClient do
   #
 
   defp config, do: Elixir.Application.get_env(:timber, __MODULE__, [])
-  defp only_log_methods, do: Keyword.get(config(), :only_log_methods, true) == true
+  defp only_log_methods, do: Keyword.get(config(), :only_log_methods, @only_log_methods_default) == true
 end

--- a/test/lib/timber/events/http_request_event_test.exs
+++ b/test/lib/timber/events/http_request_event_test.exs
@@ -18,9 +18,9 @@ defmodule Timber.Events.HTTPRequestEventTest do
       assert result.headers_json == "{\"x-request-id\":\"value\",\"user-agent\":\"agent\",\"random-header\":\"value\"}"
     end
 
-    test "deletes body" do
-      result = HTTPRequestEvent.new(body: String.duplicate("a", 2001), host: "host", method: :get, path: "path", port: 12, scheme: "https")
-      assert result.body == nil
+    test "truncates body" do
+      result = HTTPRequestEvent.new(body: String.duplicate("a", 2049), host: "host", method: :get, path: "path", port: 12, scheme: "https")
+      assert result.body == String.duplicate("a", 2033) <> " (truncated)"
     end
 
     test "normalizes method" do
@@ -51,9 +51,9 @@ defmodule Timber.Events.HTTPRequestEventTest do
     test "outgoing, service name and query string" do
       headers = [{"user-agent", "agent"}, {"x-request-id", "abcd1234"}]
       event = HTTPRequestEvent.new(direction: "outgoing", headers: headers, host: "host", method: :get,
-        path: "path", port: 12, query_string: "query", request_id: "abcd1234", scheme: "https", service_name: "service")
+        path: "/path", port: 12, query_string: "query", request_id: "abcd1234", scheme: "https", service_name: "service")
       message = HTTPRequestEvent.message(event)
-      assert String.Chars.to_string(message) == "Sent GET https://host:12path?query (abcd12...) to service"
+      assert String.Chars.to_string(message) == "Sent GET /path (abcd12...) to service"
     end
 
     test "outgoing, service name excluded" do

--- a/test/lib/timber/events/http_response_event_test.exs
+++ b/test/lib/timber/events/http_response_event_test.exs
@@ -17,6 +17,11 @@ defmodule Timber.Events.HTTPResponseEventTest do
       assert result.headers == nil
       assert result.headers_json == "{\"x-request-id\":\"value\",\"random-header\":\"value\",\"content_type\":\"type\"}"
     end
+
+    test "truncates body" do
+      result = HTTPResponseEvent.new(body: String.duplicate("a", 2049), status: 200, time_ms: 52)
+      assert result.body == String.duplicate("a", 2033) <> " (truncated)"
+    end
   end
 
   describe "Timber.Events.HTTPResponseEvent.message/1" do


### PR DESCRIPTION
Adds a simple `Timber.Integrations.ExAwsHTTPClient` integration that can be used to log communication with AWS. By default this only logs destructive events, but can be configured to log all events. The readme has been updated with examples.