### PR TITLE
Use the default Ecto log level

### DIFF
--- a/lib/mix/tasks/timber/install/timber_config_file.ex
+++ b/lib/mix/tasks/timber/install/timber_config_file.ex
@@ -62,7 +62,7 @@ defmodule Mix.Tasks.Timber.Install.TimberConfigFile do
 
     # Structure Ecto logs
     config :#{mix_name}, #{repo_module_name},
-      loggers: [{Timber.Integrations.EctoLogger, :log, [:info]}]
+      loggers: [{Timber.Integrations.EctoLogger, :log, [:debug]}]
     """
   end
 

--- a/lib/mix/tasks/timber/install/timber_config_file.ex
+++ b/lib/mix/tasks/timber/install/timber_config_file.ex
@@ -62,7 +62,7 @@ defmodule Mix.Tasks.Timber.Install.TimberConfigFile do
 
     # Structure Ecto logs
     config :#{mix_name}, #{repo_module_name},
-      loggers: [{Timber.Integrations.EctoLogger, :log, [:debug]}]
+      loggers: [{Timber.Integrations.EctoLogger, :log, []}]
     """
   end
 

--- a/lib/timber/integrations/ecto_logger.ex
+++ b/lib/timber/integrations/ecto_logger.ex
@@ -28,7 +28,7 @@ defmodule Timber.Integrations.EctoLogger do
   ```
 
   By default, queries are logged at the `:debug` level. If you want
-  to use a custom level, simple add it to the list of arguments.
+  to use a custom level, simply add it to the list of arguments.
   For example, to log every query at the `:info` level:
 
 

--- a/test/lib/mix/tasks/timber/install/timber_config_file_test.exs
+++ b/test/lib/mix/tasks/timber/install/timber_config_file_test.exs
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Timber.Install.TimberConfigFileTest do
 
         # Structure Ecto logs
         config :my_project, MyRepoModule,
-          loggers: [{Timber.Integrations.EctoLogger, :log, [:info]}]
+          loggers: [{Timber.Integrations.EctoLogger, :log, [:debug]}]
 
         # Use Timber as the logger backend
         # Feel free to add additional backends if you want to send you logs to multiple devices.

--- a/test/lib/mix/tasks/timber/install/timber_config_file_test.exs
+++ b/test/lib/mix/tasks/timber/install/timber_config_file_test.exs
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Timber.Install.TimberConfigFileTest do
 
         # Structure Ecto logs
         config :my_project, MyRepoModule,
-          loggers: [{Timber.Integrations.EctoLogger, :log, [:debug]}]
+          loggers: [{Timber.Integrations.EctoLogger, :log, []}]
 
         # Use Timber as the logger backend
         # Feel free to add additional backends if you want to send you logs to multiple devices.

--- a/test/support/installer/fake_file_contents.ex
+++ b/test/support/installer/fake_file_contents.ex
@@ -288,7 +288,7 @@ defmodule Timber.Installer.FakeFileContents do
 
     # Structure Ecto logs
     config :timber_elixir, ElixirPhoenixExampleApp.Repo,
-      loggers: [{Timber.Integrations.EctoLogger, :log, [:info]}]
+      loggers: [{Timber.Integrations.EctoLogger, :log, [:debug]}]
 
     # Use Timber as the logger backend
     # Feel free to add additional backends if you want to send you logs to multiple devices.

--- a/test/support/installer/fake_file_contents.ex
+++ b/test/support/installer/fake_file_contents.ex
@@ -288,7 +288,7 @@ defmodule Timber.Installer.FakeFileContents do
 
     # Structure Ecto logs
     config :timber_elixir, ElixirPhoenixExampleApp.Repo,
-      loggers: [{Timber.Integrations.EctoLogger, :log, [:debug]}]
+      loggers: [{Timber.Integrations.EctoLogger, :log, []}]
 
     # Use Timber as the logger backend
     # Feel free to add additional backends if you want to send you logs to multiple devices.


### PR DESCRIPTION
This removes the `:info` level specification to instead use the Ecto default level which I believe is debug.