### PR TITLE
Make host optional for HTTPRequestEvent

### DIFF
--- a/lib/timber/events/controller_call_event.ex
+++ b/lib/timber/events/controller_call_event.ex
@@ -1,7 +1,8 @@
 defmodule Timber.Events.ControllerCallEvent do
   @moduledoc """
   The `ControllerCallEvent` represents a controller being called during the HTTP request
-  cycle.
+  cycle as defined by the Timber log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
   """
 
   @type t :: %__MODULE__{

--- a/lib/timber/events/custom_event.ex
+++ b/lib/timber/events/custom_event.ex
@@ -1,6 +1,7 @@
 defmodule Timber.Events.CustomEvent do
   @moduledoc ~S"""
-  The `CustomEvent` represents events that aren't covered elsewhere.
+  The `CustomEvent` represents events that aren't covered elsewhere as defined by the Timber
+  log event JSON schema: https://github.com/timberio/log-event-json-schema
 
   Custom events can be used to structure information about events that are central
   to your line of business like receiving credit card payments, saving a draft of a post,

--- a/lib/timber/events/error_event.ex
+++ b/lib/timber/events/error_event.ex
@@ -1,6 +1,7 @@
 defmodule Timber.Events.ErrorEvent do
   @moduledoc """
-  The `ErrorEvent` is used to track errors and exceptions.
+  The `ErrorEvent` is used to track errors and exceptions as defined by the Timber log event
+  JSON schema: https://github.com/timberio/log-event-json-schema
 
   Timber automatically tracks and structures errors and exceptions in your application. Giving
   you detailed stack traces, context, and error data.

--- a/lib/timber/events/http_request_event.ex
+++ b/lib/timber/events/http_request_event.ex
@@ -1,6 +1,9 @@
 defmodule Timber.Events.HTTPRequestEvent do
   @moduledoc """
-  The `HTTPRequestEvent` tracks HTTP requests. This gives you structured into the HTTP request
+  The `HTTPRequestEvent` tracks HTTP requests as defined by the Timber log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
+
+  This gives you structured into the HTTP request
   coming into your app as well as the ones going out (if you choose to track them).
 
   Timber can automatically track incoming HTTP requests if you use a `Plug` based framework.
@@ -25,9 +28,21 @@ defmodule Timber.Events.HTTPRequestEvent do
     service_name: nil | String.t
   }
 
-  @enforce_keys [:host, :method, :scheme]
-  defstruct [:body, :direction, :host, :headers, :headers_json, :method, :path, :port, :query_string,
-    :request_id, :scheme, :service_name]
+  @enforce_keys [:method]
+  defstruct [
+    :body,
+    :direction,
+    :host,
+    :headers,
+    :headers_json,
+    :method,
+    :path,
+    :port,
+    :query_string,
+    :request_id,
+    :scheme,
+    :service_name
+  ]
 
   @doc """
   Builds a new struct taking care to:

--- a/lib/timber/events/http_response_event.ex
+++ b/lib/timber/events/http_response_event.ex
@@ -1,8 +1,10 @@
 defmodule Timber.Events.HTTPResponseEvent do
   @moduledoc """
   The `HTTPResponseEvent` tracks HTTP responses in your app, both outgoing and
-  incoming from external services (should you choose to track these). This gives
-  you structured insight into all of your HTTP response events.
+  incoming from external services (should you choose to track these) as defined by the
+  Timber log event JSON schema: https://github.com/timberio/log-event-json-schema
+
+  This gives you structured insight into all of your HTTP response events.
 
   Timber can automatically track response events if you use a `Plug` based framework
   through `Timber.Plug`.
@@ -22,8 +24,16 @@ defmodule Timber.Events.HTTPResponseEvent do
   }
 
   @enforce_keys [:status, :time_ms]
-  defstruct [:body, :direction, :headers, :headers_json, :request_id, :service_name, :status,
-    :time_ms]
+  defstruct [
+    :body,
+    :direction,
+    :headers,
+    :headers_json,
+    :request_id,
+    :service_name,
+    :status,
+    :time_ms
+  ]
 
   @doc """
   Builds a new struct taking care to:

--- a/lib/timber/events/sql_query_event.ex
+++ b/lib/timber/events/sql_query_event.ex
@@ -1,7 +1,9 @@
 defmodule Timber.Events.SQLQueryEvent do
   @moduledoc """
-  The `SQLQueryEvent` tracks *outgoing* SQL queries. This gives you structured insight into
-  SQL query performance within your application.
+  The `SQLQueryEvent` tracks *outgoing* SQL queries as defined by the Timber log event JSON
+  schema: https://github.com/timberio/log-event-json-schema
+
+  This gives you structured insight into SQL query performance within your application.
 
   Timber can automatically track SQL query events if you use `Ecto` and setup
   `Timber.Integrations.EctoLogger`.

--- a/lib/timber/events/template_render_event.ex
+++ b/lib/timber/events/template_render_event.ex
@@ -1,7 +1,9 @@
 defmodule Timber.Events.TemplateRenderEvent do
   @moduledoc """
-  The `TemplateRenderEvent` trackes template rendering within your app. Giving you structured
-  insight into template rendering performance.
+  The `TemplateRenderEvent` trackes template rendering within your app as defined by the Timber
+  log event JSON schema: https://github.com/timberio/log-event-json-schema
+
+  Giving you structured insight into template rendering performance.
 
   Timber can automatically track template rendering events if you
   use the Phoenix framework and setup the `Timber.Integrations.PhoenixInstrumenter`.

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -43,7 +43,7 @@ defmodule Timber.LogEntry do
     time_ms: nil | float
   }
 
-  @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.0.5/schema.json"
+  @schema "https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.0.7/schema.json"
 
   @doc """
   Creates a new `LogEntry` struct


### PR DESCRIPTION
`:host` is now optional for the `Timber.Events.HTTPRequestEvent` struct. The [HTTP 1.0 specification](https://www.w3.org/Protocols/HTTP/1.0/spec.html) defines the `Host` header as optional. This PR also includes various code and docs cleanup.