### PR TITLE
Update testing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,27 @@
+---
 language: elixir
 elixir:
-- 1.5.0
-- 1.4.5
-- 1.3.4
+  - 1.5.0
+  - 1.4.5
+  - 1.3.4
 otp_release:
-- 20.0
-- 19.3
-- 18.3
+  - 20.0
+  - 19.3
+  - 18.3
 env:
   matrix:
-  - ECTO_VERSION_CONSTRAINT=omit
-  - ECTO_VERSION_CONSTRAINT=latest
-  - ECTO_VERSION_CONSTRAINT=2.1.0
-  - ECTO_VERSION_CONSTRAINT=2.0.0
-  - PHOENIX_VERSION_CONSTRAINT=omit
-  - PHOENIX_VERSION_CONSTRAINT=latest
-  - PHOENIX_VERSION_CONSTRAINT="~> 1.3.0-rc"
-  - PHOENIX_VERSION_CONSTRAINT=1.2.0
-  - PHOENIX_VERSION_CONSTRAINT=1.1.0
-  - PLUG_VERSION_CONSTRAINT=omit
-  - PLUG_VERSION_CONSTRAINT=latest
+    - ECTO_VERSION_CONSTRAINT="~> 2.0"
+    - ECTO_VERSION_CONSTRAINT="~> 2.1"
+    - PHOENIX_VERSION_CONSTRAINT="~> 1.2"
+    - PHOENIX_VERSION_CONSTRAINT="~> 1.1"
+    - PLUG_VERSION_CONSTRAINT="~> 1.2"
+    - PLUG_VERSION_CONSTRAINT="~> 1.3"
 matrix:
   exclude:
-  - elixir: 1.3.4
-    otp_release: 20.0
+    - elixir: 1.3.4
+      otp_release: 20.0
 script:
-- MIX_ENV=test mix compile && MIX_ENV=test mix test
+  - MIX_ENV=test mix test
 notifications:
   email: false
   slack:

--- a/mix.exs
+++ b/mix.exs
@@ -163,33 +163,22 @@ defmodule Timber.Mixfile do
         {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0"}
       ]
 
-    # This is used for CI to ensure we can test across multiple versions.
-    # It defaults to nil for everything else, which we handle.
-    deps =
-      case System.get_env("ECTO_VERSION_CONSTRAINT") do
-        v when v in ["latest", nil] -> deps ++ [{:ecto, "~> 2.0", optional: true}]
-        "omit" -> deps
-        v -> deps ++ [{:ecto, v, optional: true}]
-      end
-
-    # This is used for CI to ensure we can test across multiple versions
-    # It defaults to nil for everything else, which we handle.
-    deps =
-      case System.get_env("PHOENIX_VERSION_CONSTRAINT") do
-        v when v in ["latest", nil] -> deps ++ [{:phoenix, "~> 1.2 or ~> 1.3.0-rc", optional: true}]
-        "omit" -> deps
-        v -> deps ++ [{:phoenix, v, optional: true}]
-      end
-
-    # This is used for CI to ensure we can test across multiple versions
-    # It defaults to nil for everything else, which we handle.
-    deps =
-      case System.get_env("PLUG_VERSION_CONTRAINT") do
-        v when v in ["latest", nil] -> deps ++ [{:plug, "~> 1.2", optional: true}]
-        "omit" -> deps
-        v -> deps ++ [{:plug, v, optional: true}]
-      end
+    ecto_version_constraint = System.get_env("ECTO_VERSION_CONSTRAINT")
+    phoenix_version_constraint = System.get_env("PHOENIX_VERSION_CONSTRAINT")
+    plug_version_constraint = System.get_env("PLUG_VERSION_CONTRAINT")
 
     deps
+    |> add_test_dependency(:ecto, ecto_version_constraint)
+    |> add_test_dependency(:phoenix, phoenix_version_constraint)
+    |> add_test_dependency(:plug, plug_version_constraint)
+  end
+
+  # Adds test dependencies for use in the continuous integration matrix
+  defp add_test_dependency(deps, dependency, nil) do
+    deps ++ [{dependency, "> 0.0.0", only: [:test]}]
+  end
+
+  defp add_test_dependency(deps, dependency, constraint) do
+    deps ++ [{dependency, constraint, only: [:test]}]
   end
 end


### PR DESCRIPTION
The previous inclusion of testing dependencies caused the test dependencies to erroneously be declared as production dependencies.  This changes the dependencies to only be added for the test environment.

Now, by default, when a value for a dependency constraint is not defined using an environment variable, the dependency will use the latest version.

The tests are now run against the gamut of recent Ecto, Phoenix, and Plug releases. I also removed the "omit" clauses, since they didn't provide a useful effect.

Fixes timberio/timber-elixir#191