### PR TITLE
Capture Phoenix channel events

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,12 +4,12 @@
 use Mix.Config
 
 config :logger, :utc_log, true
-config :logger, :handle_otp_reports, false
 
 config :logger, backends: [:console]
 config :logger, :console,
-  format: {Timber.Formatter, :format},
-  metadata: [:timber_context, :event, :application, :file, :function, :line, :module, :meta]
+  format: {Timber.Formatter, :format}
+  # For whatever reason, ExUnut.CaptureLog does not work when metadata is passed
+  # metadata: [:timber_context, :event, :application, :file, :function, :line, :module, :meta]
 
 config :plug,
   validate_header_keys_during_test: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :sasl, :sasl_error_logger, false
 
-config :logger, level: :warn
+config :logger, level: :info
 
 config :timber,
   api_key: "api_key"

--- a/lib/mix/tasks/timber/install/web_file.ex
+++ b/lib/mix/tasks/timber/install/web_file.ex
@@ -4,14 +4,18 @@ defmodule Mix.Tasks.Timber.Install.WebFile do
   alias Mix.Tasks.Timber.Install.FileHelper
 
   def update!(file_path, api) do
+    content = FileHelper.read!(file_path)
+
+    # Disable controller logging
     pattern = ~r/use Phoenix\.Controller/
     replacement = "\\0, log: false"
+    content = FileHelper.replace_once!(content, pattern, replacement, "use Phoenix.Controller, log: false")
 
-    new_content =
-      file_path
-      |> FileHelper.read!()
-      |> FileHelper.replace_once!(pattern, replacement, "use Phoenix.Controller, log: false")
+    # Disable channel logging
+    pattern = ~r/use Phoenix\.Channel/
+    replacement = "\\0, log_join: false, log_handle_in: false"
+    content = FileHelper.replace_once!(content, pattern, replacement, "use Phoenix.Channel, log_join: false, log_handle_in: false")
 
-    FileHelper.write!(file_path, new_content, api)
+    FileHelper.write!(file_path, content, api)
   end
 end

--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -7,6 +7,8 @@ defmodule Timber.Event do
   alias Timber.Utils.Map, as: UtilsMap
 
   @type t ::
+    Events.ChannelJoinEvent    |
+    Events.ChannelReceiveEvent |
     Events.ControllerCallEvent |
     Events.CustomEvent         |
     Events.ErrorEvent          |
@@ -67,6 +69,8 @@ defmodule Timber.Event do
   sending to Timber.
   """
   @spec type(t) :: atom()
+  def type(%Events.ChannelJoinEvent{}), do: :channel_join
+  def type(%Events.ChannelReceiveEvent{}), do: :channel_receive
   def type(%Events.ControllerCallEvent{}), do: :controller_call
   def type(%Events.CustomEvent{}), do: :custom
   def type(%Events.ErrorEvent{}), do: :error

--- a/lib/timber/events/channel_join_event.ex
+++ b/lib/timber/events/channel_join_event.ex
@@ -49,6 +49,6 @@ defmodule Timber.Events.ChannelJoinEvent do
   """
   @spec message(t) :: IO.chardata
   def message(%__MODULE__{channel: channel, topic: topic}) do
-    ["Channel ", to_string(channel), " joined with \"", to_string(topic), "\""]
+    ["Joined channel ", to_string(channel), " with \"", to_string(topic), "\""]
   end
 end

--- a/lib/timber/events/channel_join_event.ex
+++ b/lib/timber/events/channel_join_event.ex
@@ -1,0 +1,54 @@
+defmodule Timber.Events.ChannelJoinEvent do
+  @moduledoc """
+  The `ChannelJoinEvent` represents a web socket channel topic being joined.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
+  """
+
+  @type t :: %__MODULE__{
+    channel: String.t,
+    topic: String.t,
+    metadata_json: String.t | nil,
+  }
+
+  @enforce_keys [:channel, :topic]
+  defstruct [
+    :channel,
+    :topic,
+    :metadata_json
+  ]
+
+  @metadata_json_byte_limit 8_192
+
+  @doc """
+  Builds a new struct taking care to:
+
+  * Converts `:params` to `:params_json` that satifies the Timber API requirements
+  """
+  @spec new(Keyword.t) :: t
+  def new(opts) do
+    metadata_json =
+      case Keyword.get(opts, :metadata_json, nil) do
+        nil ->
+          nil
+
+        metadata_json ->
+          metadata_json
+          |> Timber.Utils.Logger.truncate_bytes(@metadata_json_byte_limit)
+          |> to_string()
+      end
+
+    new_opts = Keyword.put(opts, :metadata_json, metadata_json)
+
+    struct!(__MODULE__, new_opts)
+  end
+
+  @doc """
+  Message to be used when logging.
+  """
+  @spec message(t) :: IO.chardata
+  def message(%__MODULE__{channel: channel, topic: topic}) do
+    ["Channel ", to_string(channel), " joined with \"", to_string(topic), "\""]
+  end
+end

--- a/lib/timber/events/channel_receive_event.ex
+++ b/lib/timber/events/channel_receive_event.ex
@@ -51,6 +51,6 @@ defmodule Timber.Events.ChannelReceiveEvent do
   """
   @spec message(t) :: IO.chardata
   def message(%__MODULE__{channel: channel, topic: topic, event: event}) do
-    ["Incoming ", inspect(event), " on ", to_string(topic), " to ", to_string(channel)]
+    ["Received ", to_string(event), " on ", to_string(topic), " to ", to_string(channel)]
   end
 end

--- a/lib/timber/events/channel_receive_event.ex
+++ b/lib/timber/events/channel_receive_event.ex
@@ -1,0 +1,56 @@
+defmodule Timber.Events.ChannelReceiveEvent do
+  @moduledoc """
+  The `ChannelReceiveEvent` represents the reception of an event for a given topic on a channel.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
+  """
+
+  @type t :: %__MODULE__{
+    channel: String.t,
+    topic: String.t,
+    event: String.t,
+    metadata_json: String.t | nil,
+  }
+
+  @enforce_keys [:channel, :topic, :event]
+  defstruct [
+    :channel,
+    :topic,
+    :event,
+    :metadata_json
+  ]
+
+  @metadata_json_byte_limit 8_192
+
+  @doc """
+  Builds a new struct taking care to:
+
+  * Converts `:params` to `:params_json` that satifies the Timber API requirements
+  """
+  @spec new(Keyword.t) :: t
+  def new(opts) do
+    metadata_json =
+      case Keyword.get(opts, :metadata_json, nil) do
+        nil ->
+          nil
+
+        metadata_json ->
+          metadata_json
+          |> Timber.Utils.Logger.truncate_bytes(@metadata_json_byte_limit)
+          |> to_string()
+      end
+
+    new_opts = Keyword.put(opts, :metadata_json, metadata_json)
+
+    struct!(__MODULE__, new_opts)
+  end
+
+  @doc """
+  Message to be used when logging.
+  """
+  @spec message(t) :: IO.chardata
+  def message(%__MODULE__{channel: channel, topic: topic, event: event}) do
+    ["Incoming ", inspect(event), " on ", to_string(topic), " to ", to_string(channel)]
+  end
+end

--- a/lib/timber/events/channel_receive_event.ex
+++ b/lib/timber/events/channel_receive_event.ex
@@ -51,6 +51,6 @@ defmodule Timber.Events.ChannelReceiveEvent do
   """
   @spec message(t) :: IO.chardata
   def message(%__MODULE__{channel: channel, topic: topic, event: event}) do
-    ["Received ", to_string(event), " on ", to_string(topic), " to ", to_string(channel)]
+    ["Received ", to_string(event), " on \"", to_string(topic), "\" to ", to_string(channel)]
   end
 end

--- a/lib/timber/events/controller_call_event.ex
+++ b/lib/timber/events/controller_call_event.ex
@@ -1,7 +1,9 @@
 defmodule Timber.Events.ControllerCallEvent do
   @moduledoc """
   The `ControllerCallEvent` represents a controller being called during the HTTP request
-  cycle as defined by the Timber log event JSON schema:
+  cycle.
+
+  The defined structure of this data can be found in the log event JSON schema:
   https://github.com/timberio/log-event-json-schema
   """
 
@@ -9,6 +11,7 @@ defmodule Timber.Events.ControllerCallEvent do
     action: String.t,
     controller: String.t,
     params_json: String.t | nil,
+    pipelines: String.t | nil
   }
 
   @enforce_keys [:action, :controller]
@@ -39,12 +42,12 @@ defmodule Timber.Events.ControllerCallEvent do
         nil
       end
 
-    %__MODULE__{
-      action: Keyword.get(opts, :action),
-      controller: Keyword.get(opts, :controller),
-      params_json: params_json,
-      pipelines: Keyword.get(opts, :pipelines)
-    }
+    new_opts =
+      opts
+      |> Keyword.delete(:params)
+      |> Keyword.put(:params_json, params_json)
+
+    struct!(__MODULE__, new_opts)
   end
 
   @doc """

--- a/lib/timber/events/custom_event.ex
+++ b/lib/timber/events/custom_event.ex
@@ -1,7 +1,9 @@
 defmodule Timber.Events.CustomEvent do
   @moduledoc ~S"""
-  The `CustomEvent` represents events that aren't covered elsewhere as defined by the Timber
-  log event JSON schema: https://github.com/timberio/log-event-json-schema
+  The `CustomEvent` represents events that aren't covered elsewhere.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
 
   Custom events can be used to structure information about events that are central
   to your line of business like receiving credit card payments, saving a draft of a post,

--- a/lib/timber/events/error_event.ex
+++ b/lib/timber/events/error_event.ex
@@ -1,7 +1,9 @@
 defmodule Timber.Events.ErrorEvent do
   @moduledoc """
-  The `ErrorEvent` is used to track errors and exceptions as defined by the Timber log event
-  JSON schema: https://github.com/timberio/log-event-json-schema
+  The `ErrorEvent` is used to track errors and exceptions.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
 
   Timber automatically tracks and structures errors and exceptions in your application. Giving
   you detailed stack traces, context, and error data.
@@ -24,11 +26,11 @@ defmodule Timber.Events.ErrorEvent do
   @type t :: %__MODULE__{
     backtrace: [backtrace_entry] | [],
     name: String.t,
-    message: String.t,
-    metadata_json: nil | binary
+    message: String.t | nil,
+    metadata_json: binary | nil
   }
 
-  @enforce_keys [:name, :message]
+  @enforce_keys [:name]
   defstruct [:backtrace, :name, :message, :metadata_json]
 
   @app_name_byte_limit 256
@@ -70,12 +72,13 @@ defmodule Timber.Events.ErrorEvent do
           |> to_string()
       end
 
-    %__MODULE__{
+    struct!(
+      __MODULE__,
       name: name,
       message: message,
       backtrace: backtrace,
       metadata_json: metadata_json
-    }
+    )
   end
 
   @doc """

--- a/lib/timber/events/http_request_event.ex
+++ b/lib/timber/events/http_request_event.ex
@@ -1,10 +1,12 @@
 defmodule Timber.Events.HTTPRequestEvent do
   @moduledoc """
-  The `HTTPRequestEvent` tracks HTTP requests as defined by the Timber log event JSON schema:
-  https://github.com/timberio/log-event-json-schema
+  The `HTTPRequestEvent` tracks HTTP requests.
 
   This gives you structured into the HTTP request
   coming into your app as well as the ones going out (if you choose to track them).
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
 
   Timber can automatically track incoming HTTP requests if you use a `Plug` based framework.
   See the documentation for `Timber.Integerations.EventPlug` for more information. The `README.md`
@@ -16,7 +18,7 @@ defmodule Timber.Events.HTTPRequestEvent do
   @type t :: %__MODULE__{
     body: String.t | nil,
     direction: String.t | nil,
-    host: String.t,
+    host: String.t | nil,
     headers: map | nil,
     headers_json: String.t | nil,
     method: String.t,
@@ -24,7 +26,7 @@ defmodule Timber.Events.HTTPRequestEvent do
     port: pos_integer | nil,
     query_string: String.t | nil,
     request_id: String.t | nil,
-    scheme: String.t,
+    scheme: String.t | nil,
     service_name: nil | String.t
   }
 

--- a/lib/timber/events/http_response_event.ex
+++ b/lib/timber/events/http_response_event.ex
@@ -1,10 +1,12 @@
 defmodule Timber.Events.HTTPResponseEvent do
   @moduledoc """
   The `HTTPResponseEvent` tracks HTTP responses in your app, both outgoing and
-  incoming from external services (should you choose to track these) as defined by the
-  Timber log event JSON schema: https://github.com/timberio/log-event-json-schema
+  incoming from external services (should you choose to track these).
 
   This gives you structured insight into all of your HTTP response events.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
 
   Timber can automatically track response events if you use a `Plug` based framework
   through `Timber.Plug`.

--- a/lib/timber/events/sql_query_event.ex
+++ b/lib/timber/events/sql_query_event.ex
@@ -1,9 +1,11 @@
 defmodule Timber.Events.SQLQueryEvent do
   @moduledoc """
-  The `SQLQueryEvent` tracks *outgoing* SQL queries as defined by the Timber log event JSON
-  schema: https://github.com/timberio/log-event-json-schema
+  The `SQLQueryEvent` tracks *outgoing* SQL queries.
 
   This gives you structured insight into SQL query performance within your application.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
 
   Timber can automatically track SQL query events if you use `Ecto` and setup
   `Timber.Integrations.EctoLogger`.

--- a/lib/timber/events/template_render_event.ex
+++ b/lib/timber/events/template_render_event.ex
@@ -1,17 +1,19 @@
 defmodule Timber.Events.TemplateRenderEvent do
   @moduledoc """
-  The `TemplateRenderEvent` trackes template rendering within your app as defined by the Timber
-  log event JSON schema: https://github.com/timberio/log-event-json-schema
+  The `TemplateRenderEvent` trackes template rendering within your app.
 
   Giving you structured insight into template rendering performance.
+
+  The defined structure of this data can be found in the log event JSON schema:
+  https://github.com/timberio/log-event-json-schema
 
   Timber can automatically track template rendering events if you
   use the Phoenix framework and setup the `Timber.Integrations.PhoenixInstrumenter`.
   """
 
   @type t :: %__MODULE__{
-    name: String.t | nil,
-    time_ms: float | nil,
+    name: String.t,
+    time_ms: float,
   }
 
   @enforce_keys [:name, :time_ms]

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -254,7 +254,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
   defp filter_params(_params),
     do: %{}
 
-  defp try_atom_to_string(atom) when is_atom(t) do
+  defp try_atom_to_string(atom) when is_atom(atom) do
     Atom.to_string(atom)
   end
 

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -245,9 +245,13 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     do: %{}
 
   defp filter_params(params) when is_list(params) or is_map(params) do
-    params
-    |> Phoenix.Logger.filter_values()
-    |> Enum.into(%{})
+    if function_exported?(Phoenix.Logger, :filter_values, 1) do
+      params
+      |> Phoenix.Logger.filter_values()
+      |> Enum.into(%{})
+    else
+      params
+    end
   end
 
   # Unknown type, convert to a blank map for now

--- a/test/lib/timber/formatter_test.exs
+++ b/test/lib/timber/formatter_test.exs
@@ -11,7 +11,7 @@ defmodule Timber.FormatterTest do
         Logger.error("log message")
       end)
 
-      assert log_output =~ "runtime.function"
+      assert log_output =~ " @metadata "
     end
   end
 end

--- a/test/lib/timber/integrations/context_plug_test.exs
+++ b/test/lib/timber/integrations/context_plug_test.exs
@@ -1,3 +1,5 @@
-defmodule Timber.Integrations.ContextPlugTest do
-  use Timber.TestCase
+if Code.ensure_loaded?(Plug) do
+  defmodule Timber.Integrations.ContextPlugTest do
+    use Timber.TestCase
+  end
 end

--- a/test/lib/timber/integrations/http_context_plug_test.exs
+++ b/test/lib/timber/integrations/http_context_plug_test.exs
@@ -1,80 +1,82 @@
-defmodule Timber.Integrations.HTTPContextPlugTest do
-  use Timber.TestCase
+if Code.ensure_loaded?(Plug) do
+  defmodule Timber.Integrations.HTTPContextPlugTest do
+    use Timber.TestCase
 
-  alias Timber.Integrations.HTTPContextPlug
+    alias Timber.Integrations.HTTPContextPlug
 
-  setup do
-    conn = Plug.Test.conn(:get, "/")
+    setup do
+      conn = Plug.Test.conn(:get, "/")
 
-    {:ok, conn: conn}
-  end
-
-  describe "Timber.Integrations.HTTPContextPlug.call/2" do
-    test "captures HTTP method" do
-      conn = Plug.Test.conn(:delete, "/")
-
-      HTTPContextPlug.call(conn, [])
-
-      context = get_request_context()
-
-      assert context.method == "DELETE"
+      {:ok, conn: conn}
     end
 
-    test "captures HTTP path" do
-      conn = Plug.Test.conn(:get, "/articles/1234")
+    describe "Timber.Integrations.HTTPContextPlug.call/2" do
+      test "captures HTTP method" do
+        conn = Plug.Test.conn(:delete, "/")
 
-      HTTPContextPlug.call(conn, [])
+        HTTPContextPlug.call(conn, [])
 
-      context = get_request_context()
+        context = get_request_context()
 
-      assert context.path == "/articles/1234"
+        assert context.method == "DELETE"
+      end
+
+      test "captures HTTP path" do
+        conn = Plug.Test.conn(:get, "/articles/1234")
+
+        HTTPContextPlug.call(conn, [])
+
+        context = get_request_context()
+
+        assert context.path == "/articles/1234"
+      end
+
+      test "captures remote address", %{conn: conn} do
+        conn = %Plug.Conn{ conn | remote_ip: {127, 0, 0, 1} }
+
+        HTTPContextPlug.call(conn, [])
+
+        context = get_request_context()
+
+        assert context.remote_addr == "127.0.0.1"
+      end
+
+      test "captures X-Request-ID header", %{conn: conn} do
+        request_id = "abcdefg"
+
+        new_conn = Plug.Conn.put_req_header(conn, "x-request-id", request_id)
+
+        HTTPContextPlug.call(new_conn, [])
+
+        context = get_request_context()
+
+        context_request_id = context.request_id
+
+        assert context_request_id == request_id
+      end
+
+      test "captures request ID from custom header", %{conn: conn} do
+        request_id_header = "x-timbertrace-id"
+        request_id = "abcdefg"
+
+        new_conn = Plug.Conn.put_req_header(conn, request_id_header, request_id)
+
+        HTTPContextPlug.call(new_conn, [request_id_header: request_id_header])
+
+        context = get_request_context()
+
+        context_request_id = context.request_id
+
+        assert context_request_id == request_id
+      end
     end
 
-    test "captures remote address", %{conn: conn} do
-      conn = %Plug.Conn{ conn | remote_ip: {127, 0, 0, 1} }
+    def get_request_context() do
+      metadata = Logger.metadata()
 
-      HTTPContextPlug.call(conn, [])
-
-      context = get_request_context()
-
-      assert context.remote_addr == "127.0.0.1"
+      metadata
+      |> Keyword.get(:timber_context)
+      |> Map.get(:http)
     end
-
-    test "captures X-Request-ID header", %{conn: conn} do
-      request_id = "abcdefg"
-
-      new_conn = Plug.Conn.put_req_header(conn, "x-request-id", request_id)
-
-      HTTPContextPlug.call(new_conn, [])
-
-      context = get_request_context()
-
-      context_request_id = context.request_id
-
-      assert context_request_id == request_id
-    end
-
-    test "captures request ID from custom header", %{conn: conn} do
-      request_id_header = "x-timbertrace-id"
-      request_id = "abcdefg"
-
-      new_conn = Plug.Conn.put_req_header(conn, request_id_header, request_id)
-
-      HTTPContextPlug.call(new_conn, [request_id_header: request_id_header])
-
-      context = get_request_context()
-
-      context_request_id = context.request_id
-
-      assert context_request_id == request_id
-    end
-  end
-
-  def get_request_context() do
-    metadata = Logger.metadata()
-
-    metadata
-    |> Keyword.get(:timber_context)
-    |> Map.get(:http)
   end
 end

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -1,0 +1,29 @@
+defmodule Timber.Integrations.PhoenixInstrumenterTest do
+  use Timber.TestCase
+
+  import ExUnit.CaptureLog
+
+  alias Timber.Integrations.PhoenixInstrumenter
+
+  require Logger
+
+  describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_join/3" do
+    test "logs phoenix_channel_join as configured by the channel" do
+      log = capture_log(fn ->
+        socket = %Phoenix.Socket{channel: :channel, topic: "topic", private: %{log_join: :info}}
+        PhoenixInstrumenter.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{key: "val"}})
+      end)
+      assert log =~ "Channel :channel joined with \"topic\" @metadata "
+    end
+  end
+
+  describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_receive/3" do
+    test "logs phoenix_channel_receive as configured by the channel" do
+      log = capture_log(fn ->
+        socket = %Phoenix.Socket{channel: :channel, topic: "topic", private: %{log_handle_in: :info}}
+        PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
+      end)
+      assert log =~ "Incoming \"e\" on topic to :channel @metadata "
+    end
+  end
+end

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -10,7 +10,7 @@ defmodule Timber.Integrations.PhoenixInstrumenterTest do
   describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_join/3" do
     test "logs phoenix_channel_join as configured by the channel" do
       log = capture_log(fn ->
-        socket = %Phoenix.Socket{channel: :channel, topic: "topic", private: %{log_join: :info}}
+        socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
         PhoenixInstrumenter.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{key: "val"}})
       end)
       assert log =~ "Channel :channel joined with \"topic\" @metadata "
@@ -20,7 +20,7 @@ defmodule Timber.Integrations.PhoenixInstrumenterTest do
   describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_receive/3" do
     test "logs phoenix_channel_receive as configured by the channel" do
       log = capture_log(fn ->
-        socket = %Phoenix.Socket{channel: :channel, topic: "topic", private: %{log_handle_in: :info}}
+        socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
         PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
       end)
       assert log =~ "Incoming \"e\" on topic to :channel @metadata "

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -14,7 +14,7 @@ if Code.ensure_loaded?(Phoenix) do
           socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
           PhoenixInstrumenter.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{key: "val"}})
         end)
-        assert log =~ "Channel :channel joined with \"topic\" @metadata "
+        assert log =~ "Joined channel channel with \"topic\" @metadata "
       end
     end
 
@@ -24,7 +24,7 @@ if Code.ensure_loaded?(Phoenix) do
           socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
           PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
         end)
-        assert log =~ "Incoming \"e\" on topic to :channel @metadata "
+        assert log =~ "Received e on \"topic\" to channel @metadata "
       end
     end
   end

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -1,29 +1,31 @@
-defmodule Timber.Integrations.PhoenixInstrumenterTest do
-  use Timber.TestCase
+if Code.ensure_loaded?(Phoenix) do
+  defmodule Timber.Integrations.PhoenixInstrumenterTest do
+    use Timber.TestCase
 
-  import ExUnit.CaptureLog
+    import ExUnit.CaptureLog
 
-  alias Timber.Integrations.PhoenixInstrumenter
+    alias Timber.Integrations.PhoenixInstrumenter
 
-  require Logger
+    require Logger
 
-  describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_join/3" do
-    test "logs phoenix_channel_join as configured by the channel" do
-      log = capture_log(fn ->
-        socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
-        PhoenixInstrumenter.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{key: "val"}})
-      end)
-      assert log =~ "Channel :channel joined with \"topic\" @metadata "
+    describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_join/3" do
+      test "logs phoenix_channel_join as configured by the channel" do
+        log = capture_log(fn ->
+          socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
+          PhoenixInstrumenter.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{key: "val"}})
+        end)
+        assert log =~ "Channel :channel joined with \"topic\" @metadata "
+      end
     end
-  end
 
-  describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_receive/3" do
-    test "logs phoenix_channel_receive as configured by the channel" do
-      log = capture_log(fn ->
-        socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
-        PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
-      end)
-      assert log =~ "Incoming \"e\" on topic to :channel @metadata "
+    describe "Timber.Integrations.PhoenixInstrumenter.phoenix_channel_receive/3" do
+      test "logs phoenix_channel_receive as configured by the channel" do
+        log = capture_log(fn ->
+          socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
+          PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
+        end)
+        assert log =~ "Incoming \"e\" on topic to :channel @metadata "
+      end
     end
   end
 end

--- a/test/lib/timber/integrations/session_context_plug_test.exs
+++ b/test/lib/timber/integrations/session_context_plug_test.exs
@@ -1,51 +1,53 @@
-defmodule TImber.Integrations.SessionContextPlugTest do
-  use Timber.TestCase
+if Code.ensure_loaded?(Plug) do
+  defmodule TImber.Integrations.SessionContextPlugTest do
+    use Timber.TestCase
 
-  alias Timber.Integrations.SessionContextPlug
+    alias Timber.Integrations.SessionContextPlug
 
-  setup do
-    conn =
-      :get
-      |> Plug.Test.conn("/")
-      |> Plug.Test.init_test_session(%{})
+    setup do
+      conn =
+        :get
+        |> Plug.Test.conn("/")
+        |> Plug.Test.init_test_session(%{})
 
-    {:ok, conn: conn}
-  end
-
-  describe "Timber.Integrations.SessionContextPlug.call/2" do
-    test "retrieves an existing Timber session ID from the session", %{conn: conn} do
-      timber_session_id = "timber"
-
-      conn = Plug.Test.init_test_session(conn, %{:_timber_session_id => timber_session_id})
-
-      conn = SessionContextPlug.call(conn, [])
-
-      conn_session_id = Plug.Conn.get_session(conn, :_timber_session_id)
-
-      context_session_id = get_session_context_id()
-
-      assert conn_session_id == timber_session_id
-      assert context_session_id == timber_session_id
+      {:ok, conn: conn}
     end
 
-    test "sets a new Timber session ID if one does not exist", %{conn: conn} do
-      conn = SessionContextPlug.call(conn, [])
+    describe "Timber.Integrations.SessionContextPlug.call/2" do
+      test "retrieves an existing Timber session ID from the session", %{conn: conn} do
+        timber_session_id = "timber"
 
-      conn_session_id = Plug.Conn.get_session(conn, :_timber_session_id)
+        conn = Plug.Test.init_test_session(conn, %{:_timber_session_id => timber_session_id})
 
-      context_session_id = get_session_context_id()
+        conn = SessionContextPlug.call(conn, [])
 
-      refute is_nil(conn_session_id)
-      refute is_nil(context_session_id)
+        conn_session_id = Plug.Conn.get_session(conn, :_timber_session_id)
+
+        context_session_id = get_session_context_id()
+
+        assert conn_session_id == timber_session_id
+        assert context_session_id == timber_session_id
+      end
+
+      test "sets a new Timber session ID if one does not exist", %{conn: conn} do
+        conn = SessionContextPlug.call(conn, [])
+
+        conn_session_id = Plug.Conn.get_session(conn, :_timber_session_id)
+
+        context_session_id = get_session_context_id()
+
+        refute is_nil(conn_session_id)
+        refute is_nil(context_session_id)
+      end
     end
-  end
 
-  def get_session_context_id() do
-    metadata = Logger.metadata()
+    def get_session_context_id do
+      metadata = Logger.metadata()
 
-    metadata
-    |> Keyword.get(:timber_context)
-    |> Map.get(:session)
-    |> Map.get(:id)
+      metadata
+      |> Keyword.get(:timber_context)
+      |> Map.get(:session)
+      |> Map.get(:id)
+    end
   end
 end

--- a/test/support/installer/fake_file_contents.ex
+++ b/test/support/installer/fake_file_contents.ex
@@ -262,7 +262,7 @@ defmodule Timber.Installer.FakeFileContents do
 
       def channel do
         quote do
-          use Phoenix.Channel
+          use Phoenix.Channel, log_join: false, log_handle_in: false
 
           alias TimberElixir.Repo
           import Ecto


### PR DESCRIPTION
This structures the Phoenix channel join and receive events. The installer has been updated to disable `Phoenix.Channel` logging. Existing users will need to disable logging by applying the following change:

```diff
# web.ex
def channel do
    quote do
-      use Phoenix.Channel
+      use Phoenix.Channel, log_join: false, log_handle_in: false
```

Because the `Timber.Integrations.PhoenixInstrumenter` is already installed, channel events will automatically be picked up and logged. Only the above change is needed.

Closes https://github.com/timberio/timber-elixir/issues/178