### PR TITLE
Allow a threshold to be specified to log Ecto SQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,25 @@ everything from our search syntax to alerting and graphin.
 
 </p></details>
 
+## Configuration
+
+Below are a few popular configuration settings. A comprehensive list can be found in the [Timber.Config documentation](https://hexdocs.pm/timber/Timber.Config.html#content).
+
+<details><summary><strong>Only log slow Ecto SQL queries</strong></summary><p>
+
+Logging SQL queries can be useful but noisy. To reduce the volume of SQL queries you can
+limit your logging to queries that surpass an execution time threshold:
+
+```elixir
+config :timber, Timber.Integrations.EctoLogger,
+  query_time_ms_threshold: 2_000 # 2 seconds
+```
+
+In the above example, only queries that exceed 2 seconds in execution
+time will be logged.
+
+</p></details>
+
 
 ## Integrations
 

--- a/lib/timber/integrations/ecto_logger.ex
+++ b/lib/timber/integrations/ecto_logger.ex
@@ -88,7 +88,7 @@ defmodule Timber.Integrations.EctoLogger do
         time_ms = System.convert_time_unit(time_native, :native, :milliseconds)
         query_time_ms_threshold = get_query_time_ms_threshold()
 
-        if time_ms > query_time_ms_threshold do
+        if time_ms >= query_time_ms_threshold do
           event = %SQLQueryEvent{
             sql: query_text,
             time_ms: time_ms

--- a/test/lib/timber/integrations/ecto_logger_test.exs
+++ b/test/lib/timber/integrations/ecto_logger_test.exs
@@ -11,7 +11,7 @@ if Code.ensure_loaded?(Ecto) do
     describe "Timber.Integrations.EctoLogger.log/2" do
       test "exceeds the query threshold" do
         query = "SELECT * FROM table"
-        timer = :os.system_time(:millisecond)
+        timer = 0
 
         log = capture_log(fn ->
           EctoLogger.log(%{query: query, query_time: timer}, :info)

--- a/test/lib/timber/integrations/ecto_logger_test.exs
+++ b/test/lib/timber/integrations/ecto_logger_test.exs
@@ -1,0 +1,25 @@
+if Code.ensure_loaded?(Ecto) do
+  defmodule Timber.Integrations.EctoLoggerTest do
+    use Timber.TestCase
+
+    import ExUnit.CaptureLog
+
+    alias Timber.Integrations.EctoLogger
+
+    require Logger
+
+    describe "Timber.Integrations.EctoLogger.log/2" do
+      test "exceeds the query threshold" do
+        query = "SELECT * FROM table"
+        timer = :os.system_time(:millisecond)
+
+        log = capture_log(fn ->
+          EctoLogger.log(%{query: query, query_time: timer}, :info)
+        end)
+
+        assert log =~ "Processed SELECT * FROM table in"
+        assert log =~ " @metadata "
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows a query time threshold to be specified in order for an SQL query to be logged. It can be enabled like:

```elixir
config :timber, Timber.Integrations.EctoLogger,
  query_time_ms_threshold: 2_000 # 2 seconds
```

Closes https://github.com/timberio/timber-elixir/issues/197