### PR TITLE
Add an Events module for documentation / linking purposes

### DIFF
--- a/lib/timber/events.ex
+++ b/lib/timber/events.ex
@@ -1,0 +1,12 @@
+defmodule Timber.Events do
+  @moduledoc """
+  A top-level namespace that holds all Timber events. Each event is a formal defininition
+  of various popular events used in Elixir logging. Most of these events are logged for
+  you through our integrations (`Timber.Integrations`), but you can define your own custom
+  events (`Timber.Events.CustomEvent`) to extend beyond the basic events Timber provides.
+
+  We recommend reviewing the docs for both `Timber.Integrations` as well as
+  `Timber.Events.CustomEvent` to understand how events are logged and how you can log them
+  yourself.
+  """
+end


### PR DESCRIPTION
This allows us to link to the events namespace. It also provides very basic documentation for this module.