### PR TITLE
Allow Hackney 1.9 😬

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -158,7 +158,7 @@ defmodule Timber.Mixfile do
 
         # Hackney is pinned because other versions are known to have bugs. This is the
         # safest route.
-        {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6"},
+        {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9"},
         {:msgpax, "~> 1.0"},
         {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0"}
       ]


### PR DESCRIPTION
This allows for hackney `1.9.X`. Our policy is to follow the lead of the [ExAWS](https://github.com/CargoSense/ex_aws/blob/master/mix.exs#L39) library, which appears to have allowed 1.9 as well.

Closes https://github.com/timberio/timber-elixir/issues/203