### PR TITLE
Escape new lines for messages only

### DIFF
--- a/lib/timber/formatter.ex
+++ b/lib/timber/formatter.ex
@@ -161,17 +161,18 @@ defmodule Timber.Formatter do
     metadata =
       if configuration.print_metadata do
         log_entry
-        |> LogEntry.to_iodata!(configuration.format, only: [:dt, :level, :event, :context])
+        |> LogEntry.encode_to_iodata!(configuration.format, except: [:message])
         |> wrap_metadata()
       else
         []
       end
 
+    message = escape_new_lines(message, configuration.escape_new_lines)
+
     line_output =
       [message, metadata]
       |> add_log_level(level_b, configuration.print_log_level)
       |> add_timestamp(log_entry.dt, configuration.print_timestamps)
-      |> escape_new_lines(configuration.escape_new_lines)
 
     # Prevents the final new line from being escaped
     [line_output, ?\n]
@@ -231,9 +232,12 @@ defmodule Timber.Formatter do
   defp log_level_color(_), do: :normal
 
   @spec escape_new_lines(IO.chardata, boolean) :: IO.chardata
-  defp escape_new_lines(msg, false), do: msg
-  defp escape_new_lines(msg, true) do
-    to_string(msg)
+  defp escape_new_lines(message, false),
+    do: message
+
+  defp escape_new_lines(message, true) do
+    message
+    |> to_string()
     |> String.replace("\n", "\\n")
   end
 end

--- a/lib/timber/formatter.ex
+++ b/lib/timber/formatter.ex
@@ -167,12 +167,11 @@ defmodule Timber.Formatter do
         []
       end
 
-    message = escape_new_lines(message, configuration.escape_new_lines)
-
     line_output =
       [message, metadata]
       |> add_log_level(level_b, configuration.print_log_level)
       |> add_timestamp(log_entry.dt, configuration.print_timestamps)
+      |> escape_new_lines(configuration.escape_new_lines)
 
     # Prevents the final new line from being escaped
     [line_output, ?\n]

--- a/lib/timber/logger_backends/http.ex
+++ b/lib/timber/logger_backends/http.ex
@@ -24,9 +24,9 @@ defmodule Timber.LoggerBackends.HTTP do
   """
   use GenEvent
 
-  alias Timber.LogEntry
-  alias Timber.Config
   alias __MODULE__.TimberAPIKeyInvalid
+  alias Timber.Config
+  alias Timber.LogEntry
 
   require Logger
 
@@ -361,16 +361,7 @@ defmodule Timber.LoggerBackends.HTTP do
     buffer
     |> Enum.reverse()
     |> Enum.map(&LogEntry.to_map!/1)
-    |> Enum.map(&prepare_for_msgpax/1)
     |> Msgpax.pack!()
-  end
-
-  # Normalizes the LogEntry.message into a string if it is not.
-  @spec prepare_for_msgpax(LogEntry.t) :: LogEntry.t
-  defp prepare_for_msgpax(%{message: nil} = log_entry), do: log_entry
-
-  defp prepare_for_msgpax(log_entry_map) do
-    Map.put(log_entry_map, :message, IO.chardata_to_string(log_entry_map.message))
   end
 
   # Checks whether the log event level meets or exceeds the

--- a/test/lib/timber/log_entry_test.exs
+++ b/test/lib/timber/log_entry_test.exs
@@ -55,10 +55,10 @@ defmodule Timber.Events.LogEntryTest do
     end
   end
 
-  describe "Timber.LogEntry.to_iodata!/3" do
+  describe "Timber.LogEntry.encode_to_iodata!/3" do
     test "drops blanks" do
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{}}])
-      result = LogEntry.to_iodata!(entry, :json)
+      result = LogEntry.encode_to_iodata!(entry, :json)
 
       vm_pid =
         self()
@@ -70,7 +70,7 @@ defmodule Timber.Events.LogEntryTest do
 
     test "encodes JSON properly" do
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{test: "value"}}])
-      result = LogEntry.to_iodata!(entry, :json)
+      result = LogEntry.encode_to_iodata!(entry, :json)
 
       vm_pid =
         self()
@@ -84,7 +84,7 @@ defmodule Timber.Events.LogEntryTest do
       entry = LogEntry.new(time(), :info, "message", [event: %{type: :type, data: %{a: 1}}])
       system_pid = "#{entry.context.system.pid}"
       vm_pid = entry.context.runtime.vm_pid
-      result = LogEntry.to_iodata!(entry, :logfmt)
+      result = LogEntry.encode_to_iodata!(entry, :logfmt)
       assert result == [[10, 9, "Context: ", ["system.pid", 61, system_pid, 32, "system.hostname", 61, "#{hostname()}", 32, "runtime.vm_pid", 61, vm_pid]], [10, 9, "Event: ", ["custom.type.a", 61, "1"]], []]
     end
   end


### PR DESCRIPTION
This ensures that new lines are escaped in messages only when writing to the `:console` backend. This is because the format for the message is `message @metadata {...}`. The JSON encoded metadata already escapes new lines.