### PR TITLE
Clean up third party integration specifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,23 @@
+---
 language: elixir
 elixir:
-- 1.5.0
-- 1.4.5
-- 1.3.4
+  - 1.5.0
+  - 1.4.5
+  - 1.3.4
 otp_release:
-- 20.0
-- 19.3
-- 18.3
+  - 20.0
+  - 19.3
+  - 18.3
 env:
   matrix:
-  - ECTO_VERSION_CONSTRAINT=omit
-  - ECTO_VERSION_CONSTRAINT=latest
-  - ECTO_VERSION_CONSTRAINT=2.1.0
-  - ECTO_VERSION_CONSTRAINT=2.0.0
-  - PHOENIX_VERSION_CONSTRAINT=omit
-  - PHOENIX_VERSION_CONSTRAINT=latest
-  - PHOENIX_VERSION_CONSTRAINT="~> 1.3.0-rc"
-  - PHOENIX_VERSION_CONSTRAINT=1.2.0
-  - PHOENIX_VERSION_CONSTRAINT=1.1.0
-  - PLUG_VERSION_CONSTRAINT=omit
-  - PLUG_VERSION_CONSTRAINT=latest
+    - NO_THIRD_PARTY_INTEGRATION_TEST=true
+    - NO_THIRD_PARTY_INTEGRATION_TEST=false
 matrix:
   exclude:
-  - elixir: 1.3.4
-    otp_release: 20.0
+    - elixir: 1.3.4
+      otp_release: 20.0
 script:
-- MIX_ENV=test mix compile && MIX_ENV=test mix test
+  - MIX_ENV=test mix compile && mix test
 notifications:
   email: false
   slack:

--- a/mix.exs
+++ b/mix.exs
@@ -146,50 +146,58 @@ defmodule Timber.Mixfile do
   #
   #   - Keep this as the last section in `mix.exs` to make
   #     it easily discoverable
-  #   - Keep this section sorted in alphabetical order
+  #   - Keep deps categorized by direct dependencies, third-party integrations,
+  #     tooling
+  #   - Keep each category sorted in alphabetical order
+  #   - End all declarations in `,` so that they can easily be re-arranged
+  #     and sorted
   defp deps() do
-    deps =
-      [
-        {:credo, "~> 0.4", only: [:dev, :test]},
-        {:dialyxir, "~> 0.3", only: [:dev, :test]},
-        {:earmark, "~> 1.2", only: [:dev, :docs]},
-        {:ex_doc, "~> 0.15", only: [:dev, :docs]},
-        {:excoveralls, "~> 0.5", only: [:test]},
+    deps = [
+      #
+      # Direct dependencies
+      #
 
-        # Hackney is pinned because other versions are known to have bugs. This is the
-        # safest route.
-        {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9"},
-        {:msgpax, "~> 1.0"},
-        {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0"}
-      ]
+      # Hackney is pinned to known "safe" versions. While the pinned
+      # versions below are _not_ guaranteed to be bug-free, they are
+      # accepted by the community as stable.
+      {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9"},
+      {:msgpax, "~> 1.0"},
+      {:poison, "~> 1.0 or ~> 2.0 or ~> 3.0"},
 
-    # This is used for CI to ensure we can test across multiple versions.
-    # It defaults to nil for everything else, which we handle.
-    deps =
-      case System.get_env("ECTO_VERSION_CONSTRAINT") do
-        v when v in ["latest", nil] -> deps ++ [{:ecto, "~> 2.0", optional: true}]
-        "omit" -> deps
-        v -> deps ++ [{:ecto, v, optional: true}]
-      end
 
-    # This is used for CI to ensure we can test across multiple versions
-    # It defaults to nil for everything else, which we handle.
-    deps =
-      case System.get_env("PHOENIX_VERSION_CONSTRAINT") do
-        v when v in ["latest", nil] -> deps ++ [{:phoenix, "~> 1.2 or ~> 1.3.0-rc", optional: true}]
-        "omit" -> deps
-        v -> deps ++ [{:phoenix, v, optional: true}]
-      end
+      #
+      # Tooling
+      #
 
-    # This is used for CI to ensure we can test across multiple versions
-    # It defaults to nil for everything else, which we handle.
-    deps =
-      case System.get_env("PLUG_VERSION_CONTRAINT") do
-        v when v in ["latest", nil] -> deps ++ [{:plug, "~> 1.2", optional: true}]
-        "omit" -> deps
-        v -> deps ++ [{:plug, v, optional: true}]
-      end
+      {:credo, "~> 0.4", only: [:dev, :test]},
+      {:dialyxir, "~> 0.3", only: [:dev, :test]},
+      {:earmark, "~> 1.2", only: [:dev, :docs]},
+      {:ex_doc, "~> 0.15", only: [:dev, :docs]},
+      {:excoveralls, "~> 0.5", only: [:test]},
+    ]
 
-    deps
+    direct_deps = [
+      #
+      # Third-party integrations
+      #
+
+      # Note to users: we specify versions below for the third-party
+      # libraries we integrate in order to provide some guarantee about
+      # code-path compatability. If you must over-ride a dependency's
+      # version requirement, you may run into an issue where code fails.
+
+      # We support Ecto after 2.0.0 but before 2.3.0
+      {:ecto, ">= 2.0.0 and < 2.3.0", optional: true},
+      # We support Phoenix after 1.2.0 but before 1.4.0
+      {:phoenix, ">= 1.2.0 and < 1.4.0", optional: true},
+      # We support Plug after 1.2.0 but before 1.5.0
+      {:plug, ">= 1.2.0 and < 1.5.0", optional: true},
+    ]
+
+    if System.get_env("NO_THIRD_PARTY_INTEGRATION_TEST") == "true" do
+      deps
+    else
+      direct_deps ++ deps
+    end
   end
 end


### PR DESCRIPTION
This cleans up the way in which versions for third-party integrations are specified. It's much cleaner and easier to read. It also specifies the correct version range.

However, I have removed the complex testing matrix for now because the run time complexity for changes is excessive. We will need to figure out a way to better support this in the future that gives the same resilience but lowers the time it takes to get feedback on compatability.

Closes #191

Closes #218