### PR TITLE
HTTPResponseEvent no longer enforces time_ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+  - `Timber.Events.HTTPRepsonseEvent` no longer enforces the `:time_ms` key on
+    the struct. This brings it in line with the specification
 
 ## [2.5.4] - 2017-09-18
 

--- a/lib/timber/events/http_response_event.ex
+++ b/lib/timber/events/http_response_event.ex
@@ -25,7 +25,7 @@ defmodule Timber.Events.HTTPResponseEvent do
     time_ms: float
   }
 
-  @enforce_keys [:status, :time_ms]
+  @enforce_keys [:status]
   defstruct [
     :body,
     :direction,


### PR DESCRIPTION
The `Timber.Events.HTTPResponseEvent` struct was incorrectly enforcing the `:time_ms` key. The official LogEvent specficiation does not require this key.

This change removes the `:time_ms` key from the enforced keys list.

Closes #226