### PR TITLE
Housekeeping work for :gen_event switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+  - Logger backends now conform to the `:gen_event` behaviour rather than calling
+    the `GenEvent.__using__/1` macro which is deprecated in Elixir 1.5.0 and
+    above. The change is backwards compatible since `:gen_event` is provided by
+    all supported versions of Erlang.
+
 ## [2.5.5] - 2017-09-21
 
 ### Fixed

--- a/lib/mix/tasks/timber/install.ex
+++ b/lib/mix/tasks/timber/install.ex
@@ -250,7 +250,7 @@ defmodule Mix.Tasks.Timber.Install do
     |> IOHelper.write()
 
     # We manually initialize the backend here and mimic the behavior
-    # of the GenEvent system
+    # of a :gen_event manager
 
     {:ok, http_client} = Timber.LoggerBackends.HTTP.init(Timber.LoggerBackends.HTTP, [api_key: api_key])
 

--- a/lib/timber/logger_backends/http.ex
+++ b/lib/timber/logger_backends/http.ex
@@ -22,6 +22,7 @@ defmodule Timber.LoggerBackends.HTTP do
   synchronous mode, waiting for a response before proceeding with the request.
   Synchronous mode will cause any logging calls to block until the request completes.
   """
+
   @behaviour :gen_event
 
   alias __MODULE__.TimberAPIKeyInvalid
@@ -103,7 +104,7 @@ defmodule Timber.LoggerBackends.HTTP do
             ref: nil
 
   @doc false
-  # Initializes the GenEvent system for this module. This
+  # Initializes a :gen_event handler from this module. This
   # will be called by the Elixir `Logger` module when it
   # to add Timber as a logger backend.
   @spec init(__MODULE__, Keyword.t) :: {:ok, t}
@@ -120,7 +121,7 @@ defmodule Timber.LoggerBackends.HTTP do
   #
   # Note that the handle_call/2 defined here has a different return
   # structure than the one used in GenServers. This return structure
-  # is particular to GenEvent modules. See the GenEvent documentation
+  # is particular to :gen_event handlers. See the :gen_event documentation
   # for the handle_call/2 callback for more information.
   @spec handle_call({:configure, Keyword.t}, t) :: {:ok, :ok, t}
   def handle_call({:configure, options}, state) do
@@ -185,6 +186,16 @@ defmodule Timber.LoggerBackends.HTTP do
 
   # Do nothing for everything else.
   def handle_info(_, state) do
+    {:ok, state}
+  end
+
+  # No special handling for termination
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  # No special handling for code changes
+  def code_change(_old, state, _extra) do
     {:ok, state}
   end
 


### PR DESCRIPTION
This is a housekeeping commit after the change from GenEvent to :gen_event implemented in 338755c2cb0b547a8c8a87719172b7d8184b0f5c.

  - Adds a CHANGELOG.md entry
  - Adds additional functions to the `Timber.LoggerBackends.HTTP` module that were previously added by the `GenEvent.__using__/1` macro including the `terminate/2` and `code_change/3` functions.
  - Changes references in documentation and comments to `:gen_event`