### PR TITLE
Fixes instrumentation crash on no controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     above. The change is backwards compatible since `:gen_event` is provided by
     all supported versions of Erlang.
 
+### Fixed
+
+  - Fixed an error where `Timber.Integrations.PhoenixInstrumenter` would fail on render
+    events for `conn` structs that did not have a controller or action set. For
+    example, when a `conn` did not match listed routes, a `404.html` template
+    would be rendered that did not have a controller or action. The render event
+    would still be triggered though.
+
 ## [2.5.5] - 2017-09-21
 
 ### Fixed

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -179,6 +179,16 @@ if Code.ensure_loaded?(Phoenix) do
           PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{template: template_name, conn: conn})
       end
 
+      test ":start returns true when the controller/action is not available" do
+        # This test situation occurs when the route cannot be matched, for example
+        template_name = "404.html"
+
+        conn = Phoenix.ConnTest.build_conn()
+
+        assert {:ok, :info, ^template_name} =
+          PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{template: template_name, conn: conn})
+      end
+
       test ":start returns false when the controller/action is blacklisted" do
         controller = Controller
         action = :action


### PR DESCRIPTION
The controller render event for Phoenix instrumentation was encountering an error when the conn being evaluated had no controller or action set.  This occured, for example, when there was no route match and a `404.html` template was rendered.

I fixed this by checking whether there was a controller and action present first before taking them and determining their blacklist status.  The logic is slightly more convoluted but prevents the error that is currently happening.

Closes #230