### PR TITLE
Fix bad blacklist default in Phoenix integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+  - Fixed an error where `Timber.Integrations.PhoenixInstrumenter` would cause
+    an error during blacklist checks if the blacklist had not been set up.
+
   - Fixed an error where `Timber.Integrations.PhoenixInstrumenter` would fail on render
     events for `conn` structs that did not have a controller or action set. For
     example, when a `conn` did not match listed routes, a `404.html` template

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -162,7 +162,7 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
   # entry does not exist
   def get_parsed_blacklist() do
     opts = Application.get_env(:timber, __MODULE__, [])
-    Keyword.get(opts, :parsed_controller_actions_blacklist, [])
+    Keyword.get(opts, :parsed_controller_actions_blacklist, MapSet.new())
   end
 
   @doc false

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -82,6 +82,12 @@ if Code.ensure_loaded?(Phoenix) do
     end
 
     describe "Timber.Integrations.PhoenixInstrumenter.get_parsed_blacklist/0" do
+      test "retrieves empty MapSet when blacklist is not in application environment" do
+        :ok = Application.put_env(:timber, PhoenixInstrumenter, [])
+        blacklist = PhoenixInstrumenter.get_parsed_blacklist()
+        assert match?(%MapSet{}, blacklist)
+      end
+
       test "retrieves the blacklist from the application environment", %{env: env} do
         blacklist = MapSet.new([
           {A, :action},


### PR DESCRIPTION
The Phoenix integration would default to an empty list instead of an empty blacklist when trying to fetch the blacklist from the application environment. This caused an error when the blacklist was later evaluated using MapSet functions.

I aded a test that ensures the default is set correctly to an empty MapSet and updated the default appropriately.

Closes #232