### PR TITLE
Fix blacklisting issues for older Phoenix versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+  - Fixed an error where `Timber.Integrations.PhoenixInstrumenter` would fail
+    on versions of Phoenix prior to 1.3 that do not pass a `:conn` key with the
+    `phoenix_controller_render/3` `:start` event.
+
   - Fixed `Timber.Integrations.PhoenixInstrumenter` did not define a
     fall-through for `phoenix_controller_render/3` during the `:start` event for
     when the third-parameter is in a different format than expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+  - Fixed `Timber.Integrations.PhoenixInstrumenter` did not define a
+    fall-through when the instrumentation system sends a default state value for
+    the `:stop` event on `phoenix_controller_render/3`.
+
 ## [2.6.0] - 2017-09-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
   - Fixed `Timber.Integrations.PhoenixInstrumenter` did not define a
+    fall-through for `phoenix_controller_render/3` during the `:start` event for
+    when the third-parameter is in a different format than expected.
+
+  - Fixed `Timber.Integrations.PhoenixInstrumenter` did not define a
     fall-through when the instrumentation system sends a default state value for
     the `:stop` event on `phoenix_controller_render/3`.
 

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -332,6 +332,15 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     end
   end
 
+  def phoenix_controller_render(:stop, _time_diff, :ok) do
+    # The default return for phoenix_controller_render(:start, _, _) is :ok
+    # If the parameters passed are [:stop, _, :ok], it means that the :start
+    # phase failed and Phoenix is giving us :ok as the default
+    #
+    # In this case, we do nothing
+    :ok
+  end
+
   def phoenix_controller_render(:stop, _time_diff, false) do
     # The render event should not be logged
     :ok

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -93,6 +93,9 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
 
   Now, when Phoenix calls `check/2` on the `TimberClientAPI.HealthController` module,
   no log lines will be produced!
+
+  _Note_: If you're on a version of Phoenix prior to 1.3, you will still see logs for
+  render events even if the controller is blacklisted.
   """
 
   require Logger
@@ -331,6 +334,10 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     else
       handle_render_blacklist(false, template_name)
     end
+  end
+
+  def phoenix_controller_render(:start, _compile_metadata, %{template: template_name}) do
+    handle_render_blacklist(false, template_name)
   end
 
   def phoenix_controller_render(:start, _, _) do

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -320,7 +320,8 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
   end
 
   @doc false
-  @spec phoenix_controller_render(:start | :stop, map | non_neg_integer, map | :ok) :: :ok
+  @spec phoenix_controller_render(:start, map, map) :: :ok
+  @spec phoenix_controller_render(:stop, non_neg_integer, :ok | {:ok, atom, String.t} | false) :: :ok
   def phoenix_controller_render(:start, _compile_metadata, %{template: template_name, conn: conn}) do
     has_controller? = Map.has_key?(conn.private, :phoenix_controller)
     has_action? = Map.has_key?(conn.private, :phoenix_action)
@@ -330,6 +331,13 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     else
       handle_render_blacklist(false, template_name)
     end
+  end
+
+  def phoenix_controller_render(:start, _, _) do
+    # Absolute fall-through. This catch-all is provided for any scenario that
+    # has not been otherwise accounted for. It sets the return to :ok which will
+    # result in no log being produced
+    :ok
   end
 
   def phoenix_controller_render(:stop, _time_diff, :ok) do

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -210,6 +210,14 @@ if Code.ensure_loaded?(Phoenix) do
         assert false == PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{template: template_name, conn: conn})
       end
 
+      test ":stop does not log anything when the third param is :ok" do
+        log = capture_log(fn ->
+          PhoenixInstrumenter.phoenix_controller_render(:stop, %{}, :ok)
+        end)
+
+        assert log == ""
+      end
+
       test ":stop does not log anything when the third param is false" do
         log = capture_log(fn ->
           PhoenixInstrumenter.phoenix_controller_render(:stop, %{}, false)
@@ -218,7 +226,7 @@ if Code.ensure_loaded?(Phoenix) do
         assert log == ""
       end
 
-      test ":stop logs the render time when " do
+      test ":stop logs the render time when it is present" do
         template_name = "index.html"
         log_level = :info
 

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -210,6 +210,10 @@ if Code.ensure_loaded?(Phoenix) do
         assert false == PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{template: template_name, conn: conn})
       end
 
+      test ":start returns :ok when an unsupported map is passed" do
+        assert :ok = PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{})
+      end
+
       test ":stop does not log anything when the third param is :ok" do
         log = capture_log(fn ->
           PhoenixInstrumenter.phoenix_controller_render(:stop, %{}, :ok)

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -210,6 +210,14 @@ if Code.ensure_loaded?(Phoenix) do
         assert false == PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{template: template_name, conn: conn})
       end
 
+      test ":start returns true when a template name is given but no connection" do
+        # This test situation occurs when the route cannot be matched, for example
+        template_name = "404.html"
+
+        assert {:ok, :info, ^template_name} =
+          PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{template: template_name})
+      end
+
       test ":start returns :ok when an unsupported map is passed" do
         assert :ok = PhoenixInstrumenter.phoenix_controller_render(:start, %{}, %{})
       end


### PR DESCRIPTION
This fixes issues described in #238 where an older version of Phoenix would encounter failures while trying to run our integration code. This was because the older versions of Phoenix did not provide the expected `:conn` key we were looking for in the `phoenix_controller_render` event.

Now, `phoenix_controller_render` events in older versions of Phoenix will always result in log lines. Unfortunately, since we don't have a `conn`, we aren't able to detect whether they should be suppressed due to the blacklist.

This also adds some default handling for the instrumentation callbacks.

Fixes #238