### PR TITLE
add path pattern for web.ex in phx 1.3

### DIFF
--- a/lib/mix/tasks/timber/install/project.ex
+++ b/lib/mix/tasks/timber/install/project.ex
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Timber.Install.Project do
   defp get_web_file_path(api) do
     if Code.ensure_loaded?(Phoenix) do
       file_explanation = "We need this to disable the default Phoenix controller logging"
-      PathHelper.find(["web", "web.ex"], file_explanation, api, check_for_umbrella: true,
+      PathHelper.find(["{web,lib}", "*web.ex"], file_explanation, api, check_for_umbrella: true,
         contents_filter: "use Phoenix.Controller")
     else
       nil


### PR DESCRIPTION
The location of the `web/web.ex` is changed to `lib/{project}_web.ex`  in phoenix 1.3. To support this change I have change the pattern to find both `web/web.ex` and  `lib/{project}_web.ex`.