### PR TITLE
Add Global Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+  - The `Timber.LocalContext` now manages setting and updating the Timber context
+    maintained in the Elixir Logger metadata. This replaces the `Timber.CurrentContext`
+    module. `Timber.LocalContext.get/0` should be used where
+    `Timber.CurrentContext.load/0` was used before, and `Timber.LocalContext.put/1`
+    should be used where `Timber.CurrentContext.save/1` was used.
+
+### Deprecated
+
+  - `Timber.CurrentContext` has been deprecated in favor of `Timber.LocalContext`;
+    the new name better reflects the purpose of the module. Use of
+    `Timber.CurrentContext` will still be supported for the lifetime of v2
+
 ## [2.6.1] - 2017-10-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+  - `Timber.LogEntry.new/4` will fetch the global context and merge it into the
+    local metadata context. The local context will override the global context
+    based on the rules for `Timber.Context.merge/2`
+
 ### Added
 
+  - `Timber.add_context/2` now allows you to set context either locally or globally;
+    `Timber.add_context/1` will default to storing the context locally (consistent
+    with previous versions of the library)
   - The `Timber.LocalContext` now manages setting and updating the Timber context
     maintained in the Elixir Logger metadata. This replaces the `Timber.CurrentContext`
     module. `Timber.LocalContext.get/0` should be used where

--- a/README.md
+++ b/README.md
@@ -254,17 +254,17 @@ context between processes because they are related (such as processes created by
 In these instances copying the context is easy.
 
 ```elixir
-current_context = Timber.CurrentContext.load()
+current_context = Timber.LocalContext.get()
 
 Task.async fn ->
-  Timber.CurrentContext.save(current_context)
+  Timber.LocalContext.put(current_context)
   Logger.info("Logs from a separate process")
 end
 ```
 
 `current_context` in the above example is captured in the parent process, and because Elixir's
 variable scope is lexical, you can pass the referenced context into the newly created process.
-`Timber.CurrentContext.save/1` copies that context into the new process dictionary.
+`Timber.LocalContext.put/1` copies that context into the new process dictionary.
 
 * [Search it](https://timber.io/docs/app/console/searching) with queries like: `background_job.time_ms:>500`
 * [Alert on it](https://timber.io/docs/app/console/alerts) with threshold based alerts

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -8,16 +8,14 @@ defmodule Timber do
   use Application
 
   alias Timber.Context
-  alias Timber.CurrentContext
+  alias Timber.LocalContext
 
   @doc """
   Adds a context entry to the stack. See `Timber::Contexts::CustomContext` for examples.
   """
-  @spec add_context(map | Keyword.t | Context.context_element) :: :ok
+  @spec add_context(Context.element) :: :ok
   def add_context(data) do
-    CurrentContext.load()
-    |> Context.add(data)
-    |> CurrentContext.save()
+    LocalContext.add(data)
   end
 
   @doc """

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -9,13 +9,35 @@ defmodule Timber do
 
   alias Timber.Context
   alias Timber.LocalContext
+  alias Timber.GlobalContext
 
   @doc """
-  Adds a context entry to the stack. See `Timber::Contexts::CustomContext` for examples.
+  Adds Timber context to the current process
+
+  See `add_context/2`
   """
   @spec add_context(Context.element) :: :ok
-  def add_context(data) do
+  def add_context(data, location \\ :local)
+
+  @doc """
+  Adds context which will be included on log entries
+
+  The second parameter indicates where you want the context to be
+  stored. The available options are:
+
+    - `:global` - This stores the context at a global level, meaning
+      it will be present on every log line, regardless of which process
+      generates the log line.
+    - `:local` - This stores the context in the Logger Metadata which
+      is local to the process
+  """
+  @spec add_context(Context.element, :local | :global) :: :ok
+  def add_context(data, :local) do
     LocalContext.add(data)
+  end
+
+  def add_context(data, :global) do
+    GlobalContext.add(data)
   end
 
   @doc """

--- a/lib/timber/context.ex
+++ b/lib/timber/context.ex
@@ -96,6 +96,27 @@ defmodule Timber.Context do
     Map.put(context, key, new_context)
   end
 
+  @doc """
+  Merges two Context structs
+
+  Entries in the second Context will override entries in the first.
+  The caveat to this is custom context, which will descend into the
+  custom context and merge it there. Even then, custom context entries
+  in the second will override custom context entries in the first.
+  """
+  @spec merge(t, t) :: t
+  def merge(first_context, second_context) do
+    Map.merge(first_context, second_context, &c_merge/3)
+  end
+
+  defp c_merge(:custom, first_context, second_context) do
+    Map.merge(first_context, second_context)
+  end
+
+  defp c_merge(_key, first_context, _second_context) do
+    first_context
+  end
+
   # Converts a context_element into a map the Timber API expects.
   @spec to_api_map(context_element) :: map
   defp to_api_map(%Contexts.CustomContext{type: type, data: data}) do

--- a/lib/timber/context.ex
+++ b/lib/timber/context.ex
@@ -18,7 +18,14 @@ defmodule Timber.Context do
   alias Timber.Contexts
   alias Timber.Utils.Map, as: UtilsMap
 
-  @type context_element ::
+  @typedoc """
+  Deprecated; please use `element` instead
+  """
+  @type context_element :: element
+
+  @type element ::
+    map                             |
+    Keyword.t                       |
     Contexts.CustomContext.t        |
     Contexts.HTTPContext.t          |
     Contexts.JobContext.t           |

--- a/lib/timber/current_context.ex
+++ b/lib/timber/current_context.ex
@@ -1,33 +1,12 @@
 defmodule Timber.CurrentContext do
   @moduledoc """
-  Represents the current context stored in the `Elixir.Logger` metadata.
-  This module's sole purposes is to load and persist context from that metadata.
-  The actual context data structure is defined and managed in `Timber.Context`.
+  Deprecated in favor of `Timber.LocalContext`
+
+  This module has been deprecated and is scheduled for removal in
+  v3.0.0.
   """
 
-  alias Timber.Context
-
-  @doc """
-  Loads the current context from the `Elixir.Logger` metadata.
-  """
-  @spec load :: Context.t
-  def load do
-    Elixir.Logger.metadata()
-    |> extract_from_metadata()
-  end
-
-  @doc false
-  @spec extract_from_metadata(Keyword.t) :: Context.t
-  def extract_from_metadata(metadata) do
-    Keyword.get(metadata, :timber_context, Context.new())
-  end
-
-  @doc """
-  Save the provided context into the `Elixir.Logger` metadata.
-  """
-  @spec save(Context.t) :: :ok
-  def save(context) do
-    Elixir.Logger.metadata([timber_context: context])
-    :ok
-  end
+  defdelegate load(), to: Timber.LocalContext
+  defdelegate extract_from_metadata(metadata), to: Timber.LocalContext
+  defdelegate save(context), to: Timber.LocalContext
 end

--- a/lib/timber/global_context.ex
+++ b/lib/timber/global_context.ex
@@ -1,0 +1,56 @@
+defmodule Timber.GlobalContext do
+  @moduledoc """
+  Manages a globally available Timber Context
+
+  This module stores context in Timber's OTP application configuration
+  in order to support global writing and reading with high-throughput.
+  """
+
+  # The global context is set and maintained in the OTP application configuration
+  # under the :global_context key for ease-of-use. The API in this module does
+  # not assume that it will always be stored there, so if we find that storing
+  # global context here is detrimental, we can easily move it to another methodology.
+
+  alias Timber.Context
+
+  @doc """
+  Merges the provided context into the existing context
+  """
+  @spec add(Context.t) :: :ok
+  def add(context) do
+    load()
+    |> Context.add(context)
+    |> save()
+  end
+
+  @doc """
+  Dumps the context to a `Context.t`
+
+  This function is provided as a convenience to see the current global
+  context.
+  """
+  @spec get() :: Context.t
+  def get() do
+    load()
+  end
+
+  @doc """
+  Sets the global context, overriding any existing context
+  """
+  @spec put(Context.t) :: :ok
+  def put(context) do
+    save(context)
+  end
+
+  @doc false
+  @spec load() :: Context.t
+  def load() do
+    Application.get_env(:timber, :global_context, Context.new())
+  end
+
+  @doc false
+  @spec save(Context.t) :: :ok
+  def save(context) do
+    Application.put_env(:timber, :global_context, context)
+  end
+end

--- a/lib/timber/local_context.ex
+++ b/lib/timber/local_context.ex
@@ -1,0 +1,67 @@
+defmodule Timber.LocalContext do
+  @moduledoc """
+  Manages Timber context through the `Elixir.Logger` metadata
+
+  This module stores context in the `Elixir.Logger` metadata, so any context is
+  specific to the process.
+
+  For more details about the context data structure, see `Timber.Context`.
+  """
+
+  alias Timber.Context
+
+  @doc """
+  Merges the provided context into the existing context
+
+  `Timber.Context.add/2` is called to merge the existing context
+  with the provided context.
+  """
+  @spec add(Context.t) :: :ok
+  def add(context) do
+    load()
+    |> Context.add(context)
+    |> save()
+  end
+
+  @doc """
+  Dumps the context to a `Context.t`
+
+  This function is used to expose the current context, which is useful
+  if you need to copy the context to a different process.
+  """
+  @spec get() :: Context.t
+  def get() do
+    load()
+  end
+
+  @doc """
+  Sets the provided context, overriding any existing Context
+  """
+  @spec put(Context.t) :: :ok
+  def put(context) do
+    save(context)
+  end
+
+  @doc false
+  @spec load() :: Context.t
+  def load() do
+    Elixir.Logger.metadata()
+    |> extract_from_metadata()
+  end
+
+  @doc false
+  @spec extract_from_metadata(Keyword.t) :: Context.t
+  # This function is required by Timber.LogEntry to extract the context
+  # from the Logger metadata, so this function _must_ be public, but it
+  # is only intended for internal use.
+  def extract_from_metadata(metadata) do
+    Keyword.get(metadata, :timber_context, Context.new())
+  end
+
+  @doc false
+  @spec save(Context.t) :: :ok
+  def save(context) do
+    Elixir.Logger.metadata([timber_context: context])
+    :ok
+  end
+end

--- a/lib/timber/log_entry.ex
+++ b/lib/timber/log_entry.ex
@@ -74,7 +74,7 @@ defmodule Timber.LogEntry do
 
     context =
       global_context
-      |> Context.add(metadata_context)
+      |> Context.merge(metadata_context)
       |> add_runtime_context(metadata)
       |> add_system_context()
 

--- a/test/lib/timber/context_test.exs
+++ b/test/lib/timber/context_test.exs
@@ -67,4 +67,31 @@ defmodule Timber.ContextTest do
       assert result ==  %{user: %{id: "1"}}
     end
   end
+
+  describe "Timber.Context.merge/2" do
+    test "merges with two custom contexts" do
+      first_context = Context.add(%{}, %{build: %{version: "1.0.0"}})
+      second_context = Context.add(%{}, %{build: %{timestamp: "1520867239"}})
+      merged_context = Context.merge(first_context, second_context)
+
+      custom_context = Map.get(merged_context, :custom)
+      assert Map.has_key?(custom_context, :build)
+      build = Map.get(custom_context, :build)
+      assert Map.has_key?(build, :timestamp)
+      refute Map.has_key?(build, :version)
+    end
+
+    test "merges with left-side custom context" do
+      # this test makes sure that the left hand side custom context (the "first" context)
+      # is preserved when there is no right hand side custom context
+      first_context = Context.add(%{}, %{build: %{version: "1.0.0"}})
+      second_context = %{}
+      merged_context = Context.merge(first_context, second_context)
+
+      custom_context = Map.get(merged_context, :custom)
+      assert Map.has_key?(custom_context, :build)
+      build = Map.get(custom_context, :build)
+      assert Map.has_key?(build, :version)
+    end
+  end
 end


### PR DESCRIPTION
This introduces the module Timber.LocalContext to replace Timber.CurrentContext. Timber.CurrentContext was repsonsible for managing the context using the Elixir Logger metadata, which is local to a process, so the name LocalContext makes more sense. In future commits, Timber.GlobalContext will be introduced to supplement context stored in the Logger metadata.

Support for global context is added through the `Timber.GlobalContext` module as well as through the `Timber.add_context/2` helper function. Global context will be stored in the OTP application configuration for timber, but if this proves to be a poor choice, the `Timber.GlobalContext` module allows the storage locaiton to be modified without changing the API.

The global context is now merged with the local context when log events are created via `Timber.LogEntry.new/4`. The local context will overwrite the global context where they conflict.

Closes #196