### PR TITLE
Add Elixir 1.6.3 and OTP 20.2.2 to the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 ---
 language: elixir
 elixir:
+  - 1.6.3
   - 1.5.0
   - 1.4.5
   - 1.3.4
 otp_release:
+  - 20.2.2
   - 20.0
   - 19.3
   - 18.3
@@ -16,6 +18,10 @@ matrix:
   exclude:
     - elixir: 1.3.4
       otp_release: 20.0
+    - elixir: 1.3.4
+      otp_release: 20.2.2
+    - elixir: 1.6.3
+      otp_release: 18.3
 script:
   - MIX_ENV=test mix compile && mix test
 notifications:


### PR DESCRIPTION
Updates the Travis test matrix to include the latest versions of Elixir and Erlang.