### PR TITLE
Improve Phoenix Channel Param Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+  - Phoenix Channels integration with Phoneix 1.3+ will no longer fail if the
+    payload of a channel message is a list
+
 ### Changed
 
   - `Timber.LogEntry.new/4` will fetch the global context and merge it into the
     local metadata context. The local context will override the global context
     based on the rules for `Timber.Context.merge/2`
+  - Phoenix Channels integration will now accept _any_ channel message payload.
+    (Previously, non-map types were dropped and replaced with an empty map.)
 
 ### Added
 

--- a/lib/timber/integrations/phoenix_instrumenter.ex
+++ b/lib/timber/integrations/phoenix_instrumenter.ex
@@ -437,9 +437,9 @@ defmodule Timber.Integrations.PhoenixInstrumenter do
     end
   end
 
-  # Unknown type, convert to a blank map for now
-  defp filter_params(_params) do
-    %{}
+  # Non-structured type, take as-is
+  defp filter_params(params) do
+    filter_values(params)
   end
 
   defp filter_values(params) do

--- a/test/lib/timber/integrations/phoenix_instrumenter_test.exs
+++ b/test/lib/timber/integrations/phoenix_instrumenter_test.exs
@@ -133,6 +133,70 @@ if Code.ensure_loaded?(Phoenix) do
         end)
         assert log =~ "Received e on \"topic\" to channel @metadata "
       end
+
+      test "accepts a message where the params is a keyword list" do
+        log = capture_log(fn ->
+          socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
+          params = [name: "Geoffrey"]
+          metadata = %{
+            socket: socket,
+            event: "e",
+            params: params
+          }
+
+          PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, metadata)
+        end)
+
+        assert log =~ ~s/Received e on "topic" to channel @metadata /
+      end
+
+      test "accepts a message where the params is a non-Keyword list" do
+        log = capture_log(fn ->
+          socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
+          params = ["a", "b"]
+          metadata = %{
+            socket: socket,
+            event: "e",
+            params: params
+          }
+
+          PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, metadata)
+        end)
+
+        assert log =~ ~s/Received e on "topic" to channel @metadata /
+      end
+
+      test "accepts a message where the params is a string" do
+        log = capture_log(fn ->
+          socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
+          params = "61cf02ad-9509-48be-9b88-edf5e85219fe"
+          metadata = %{
+            socket: socket,
+            event: "e",
+            params: params
+          }
+
+          PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, metadata)
+        end)
+
+        assert log =~ ~s/Received e on "topic" to channel @metadata /
+      end
+
+      test "accept a message where the params ia numeric value" do
+        log = capture_log(fn ->
+          socket = %Phoenix.Socket{channel: :channel, topic: "topic"}
+          params = 3.14
+          metadata = %{
+            socket: socket,
+            event: "e",
+            params: params
+          }
+
+          PhoenixInstrumenter.phoenix_channel_receive(:start, %{}, metadata)
+        end)
+
+        assert log =~ ~s/Received e on "topic" to channel @metadata /
+      end
     end
 
     describe "Timber.Integrations.PhoenixInstrumenter.phoenix_controller_call/3" do


### PR DESCRIPTION
This fixes a bug in the Phoenix Channels integration layer. When using Phoenix 1.3+ and the channel payload is a list (not a Keyword list), the Timber.Integrations.PhoenixInstrumenter.phoenix_channel_receive/3 function would raise when trying to force the list into a map.

The logic now only coerces a list into a map if the list is a valid Keyword list (and thus can be represented by a map).

Unstructured params in Phoenix Channel payloads were being replaced by an empty map which wasn't a great experience for users. Users expect the params field to represent the params that were included in the message. This now accepts params as-is when they are not a list or map (lists and maps are handled separately).

Fixes the bug described in #258

Closes #258