### PR TITLE
more specific regex on Router

### DIFF
--- a/lib/mix/tasks/timber/install/endpoint_file.ex
+++ b/lib/mix/tasks/timber/install/endpoint_file.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Timber.Install.EndpointFile do
   alias Mix.Tasks.Timber.Install.FileHelper
 
   def update!(file_path, api) do
-    router_pattern = ~r/( *)plug [^\n\r]*.Router/
+    router_pattern = ~r/( *)plug [^\n\r]*.\.Router/
     router_replacement =
       "\\1# Add Timber plugs for capturing HTTP context and events\n" <>
         "\\1plug Timber.Integrations.SessionContextPlug\n" <>


### PR DESCRIPTION
Would now require a period before Router. `plug [stuff] .Router` instead of `plug [stuff] Router`

Closes #251 