### PR TITLE
Update endpoint_file.ex to accepts Elixir 1.6 fmt

### DIFF
--- a/lib/mix/tasks/timber/install/endpoint_file.ex
+++ b/lib/mix/tasks/timber/install/endpoint_file.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Timber.Install.EndpointFile do
   alias Mix.Tasks.Timber.Install.FileHelper
 
   def update!(file_path, api) do
-    router_pattern = ~r/( *)plug [^\n\r]*.\.Router/
+    router_pattern = ~r/( *)plug.{0,1}[^\n\r]*.\.Router.{0,1}/
     router_replacement =
       "\\1# Add Timber plugs for capturing HTTP context and events\n" <>
         "\\1plug Timber.Integrations.SessionContextPlug\n" <>


### PR DESCRIPTION
Installer fails with the endpoint.ex is formatted with the default Elixir 1.6

Works with
plug Arvore.Web.Router

Fails with:
plug(Arvore.Web.Router)