### PR TITLE
Updates the router discovery pattern

### DIFF
--- a/lib/mix/tasks/timber/install/endpoint_file.ex
+++ b/lib/mix/tasks/timber/install/endpoint_file.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Timber.Install.EndpointFile do
   alias Mix.Tasks.Timber.Install.FileHelper
 
   def update!(file_path, api) do
-    router_pattern = ~r/( *)plug.{0,1}[^\n\r]*.\.Router.{0,1}/
+    router_pattern = ~r/( *)plug\({0,1}[^\n\r]*.\.Router\){0,1}/
     router_replacement =
       "\\1# Add Timber plugs for capturing HTTP context and events\n" <>
         "\\1plug Timber.Integrations.SessionContextPlug\n" <>


### PR DESCRIPTION
This follows the change by @andrelip to make the pattern for Phoenix Endpoint plug Router declarations more specific as suggested by @mitchellhenke.