### PR TITLE
Add `Timber.remove_context_key` for removing an individual keys off of context structures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
   - Add support for inline context via the `:context` `Logger` metadata key.
+  - Add `Timber.remove_context_key` for removing an individual keys off of context structures.
 
 ## [2.8.0] - 2018-04-16
 

--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -11,19 +11,8 @@ defmodule Timber do
   alias Timber.LocalContext
   alias Timber.GlobalContext
 
-  @doc """
-  Adds Timber context to the current process
-
-  See `add_context/2`
-  """
-  @spec add_context(Context.element) :: :ok
-  def add_context(data, location \\ :local)
-
-  @doc """
-  Adds context which will be included on log entries
-
-  The second parameter indicates where you want the context to be
-  stored. The available options are:
+  @typedoc """
+  The target context to perform the operation.
 
     - `:global` - This stores the context at a global level, meaning
       it will be present on every log line, regardless of which process
@@ -31,13 +20,51 @@ defmodule Timber do
     - `:local` - This stores the context in the Logger Metadata which
       is local to the process
   """
-  @spec add_context(Context.element, :local | :global) :: :ok
+  @type context_location :: :local | :global
+
+  @doc """
+  Adds Timber context to the current process
+
+  See `add_context/2`
+  """
+  @spec add_context(Context.element()) :: :ok
+  def add_context(data, location \\ :local)
+
+  @doc """
+  Adds context which will be included on log entries
+
+  The second parameter indicates where you want the context to be
+  stored. See `context_location` for more details.
+  """
+  @spec add_context(Context.element(), context_location) :: :ok
   def add_context(data, :local) do
     LocalContext.add(data)
   end
 
   def add_context(data, :global) do
     GlobalContext.add(data)
+  end
+
+  @doc """
+  Removes a key from Timber context on the current process.
+
+  See `remove_context_key/2`
+  """
+  @spec remove_context_key(atom) :: :ok
+  def remove_context_key(key, location \\ :local)
+
+  @doc """
+  Removes a context key.
+
+  The second parameter indicates which context you want the key to be removed from.
+  """
+  @spec remove_context_key(atom, context_location) :: :ok
+  def remove_context_key(key, :local) do
+    LocalContext.remove_key(key)
+  end
+
+  def remove_context_key(key, :global) do
+    GlobalContext.remove_key(key)
   end
 
   @doc """
@@ -69,7 +96,7 @@ defmodule Timber do
 
   @doc false
   def debug(nil, _message_fun) do
-     false
+    false
   end
 
   def debug(io_device, message_fun) when is_function(message_fun) do

--- a/lib/timber/context.ex
+++ b/lib/timber/context.ex
@@ -119,6 +119,14 @@ defmodule Timber.Context do
     first_context
   end
 
+  @doc """
+  Removes a key from the provided context structure.
+  """
+  @spec remove_key(t, atom) :: t
+  def remove_key(context, key) do
+    Map.delete(context, key)
+  end
+
   # Converts a context_element into a map the Timber API expects.
   @spec to_api_map(element) :: map
   defp to_api_map(%Contexts.CustomContext{type: type, data: data}) do

--- a/lib/timber/global_context.ex
+++ b/lib/timber/global_context.ex
@@ -16,7 +16,7 @@ defmodule Timber.GlobalContext do
   @doc """
   Merges the provided context into the existing context
   """
-  @spec add(Context.element) :: :ok
+  @spec add(Context.element()) :: :ok
   def add(context) do
     load()
     |> Context.add(context)
@@ -29,7 +29,7 @@ defmodule Timber.GlobalContext do
   This function is provided as a convenience to see the current global
   context.
   """
-  @spec get() :: Context.t
+  @spec get() :: Context.t()
   def get() do
     load()
   end
@@ -37,19 +37,29 @@ defmodule Timber.GlobalContext do
   @doc """
   Sets the global context, overriding any existing context
   """
-  @spec put(Context.t) :: :ok
+  @spec put(Context.t()) :: :ok
   def put(context) do
     save(context)
   end
 
   @doc false
-  @spec load() :: Context.t
+  @spec load() :: Context.t()
   def load() do
     Application.get_env(:timber, :global_context, Context.new())
   end
 
+  @doc """
+  Removes the key from the existing context.
+  """
+  @spec remove_key(atom) :: :ok
+  def remove_key(key) do
+    load()
+    |> Context.remove_key(key)
+    |> save()
+  end
+
   @doc false
-  @spec save(Context.t) :: :ok
+  @spec save(Context.t()) :: :ok
   def save(context) do
     Application.put_env(:timber, :global_context, context)
   end

--- a/lib/timber/local_context.ex
+++ b/lib/timber/local_context.ex
@@ -16,7 +16,7 @@ defmodule Timber.LocalContext do
   `Timber.Context.add/2` is called to merge the existing context
   with the provided context.
   """
-  @spec add(Context.element) :: :ok
+  @spec add(Context.element()) :: :ok
   def add(context) do
     load()
     |> Context.add(context)
@@ -29,7 +29,7 @@ defmodule Timber.LocalContext do
   This function is used to expose the current context, which is useful
   if you need to copy the context to a different process.
   """
-  @spec get() :: Context.t
+  @spec get() :: Context.t()
   def get() do
     load()
   end
@@ -37,20 +37,20 @@ defmodule Timber.LocalContext do
   @doc """
   Sets the provided context, overriding any existing Context
   """
-  @spec put(Context.t) :: :ok
+  @spec put(Context.t()) :: :ok
   def put(context) do
     save(context)
   end
 
   @doc false
-  @spec load() :: Context.t
+  @spec load() :: Context.t()
   def load() do
     Elixir.Logger.metadata()
     |> extract_from_metadata()
   end
 
   @doc false
-  @spec extract_from_metadata(Keyword.t) :: Context.t
+  @spec extract_from_metadata(Keyword.t()) :: Context.t()
   # This function is required by Timber.LogEntry to extract the context
   # from the Logger metadata, so this function _must_ be public, but it
   # is only intended for internal use.
@@ -58,10 +58,22 @@ defmodule Timber.LocalContext do
     Keyword.get(metadata, :timber_context, Context.new())
   end
 
+  @doc """
+  Removes the key from the existing local context.
+
+  `Timber.Context.remove_key/2` is called to delete the key.
+  """
+  @spec remove_key(atom) :: :ok
+  def remove_key(key) do
+    load()
+    |> Context.remove_key(key)
+    |> save()
+  end
+
   @doc false
-  @spec save(Context.t) :: :ok
+  @spec save(Context.t()) :: :ok
   def save(context) do
-    Elixir.Logger.metadata([timber_context: context])
+    Elixir.Logger.metadata(timber_context: context)
     :ok
   end
 end


### PR DESCRIPTION
This is necessary to cleanup context upon exiting lexical scopes.