### PR TITLE
Add friendly error for wrong custom event type

### DIFF
--- a/lib/timber/event.ex
+++ b/lib/timber/event.ex
@@ -39,6 +39,10 @@ defmodule Timber.Event do
   end
 
   def to_api_map(%Events.CustomEvent{type: type, data: data}) do
+    if !is_map(data) do
+      raise ArgumentError, message: "Custom Event data must be a map"
+    end
+
     data = normalize_data(data)
     %{custom: %{type => data}}
   end
@@ -60,7 +64,7 @@ defmodule Timber.Event do
     %{type => map}
   end
 
-  defp normalize_data(data) do
+  defp normalize_data(data) when is_map(data) do
     data
     |> UtilsMap.deep_from_struct()
     |> UtilsMap.recursively_drop_blanks()

--- a/test/lib/timber/log_entry_test.exs
+++ b/test/lib/timber/log_entry_test.exs
@@ -135,6 +135,14 @@ defmodule Timber.Events.LogEntryTest do
                []
              ]
     end
+
+    test "encodes raises ArgumentError when event is not a map" do
+      entry = LogEntry.new(get_time(), :info, "message", event: %{type: 1})
+
+      assert_raise ArgumentError, fn ->
+        LogEntry.encode_to_iodata!(entry, :json)
+      end
+    end
   end
 
   defp get_vm_pid do


### PR DESCRIPTION
This adds a friendly error message when a type that isn't a map is passed
as a custom event. This should provide a clear way for a user to fix the
problem.