### PR TITLE
do not log path in HTTPRequestEvent message if path is nil

### DIFF
--- a/lib/timber/events/http_request_event.ex
+++ b/lib/timber/events/http_request_event.ex
@@ -106,6 +106,11 @@ defmodule Timber.Events.HTTPRequestEvent do
       else: message
   end
 
-  def message(%__MODULE__{} = event),
-    do: ["Received ", event.method, " ", event.path]
+  def message(%__MODULE__{} = event) do
+    if(event.path) do
+      ["Received ", event.method, " ", event.path]
+    else
+      ["Received ", event.method]
+    end
+  end
 end


### PR DESCRIPTION
Closes #243 

Should I create an issue to remove this check when support for 1.3 is dropped?