### PR TITLE
Fix exception documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ making them [easier to search and use](#do-amazing-things-with-your-logs).
   * [**Ecto**](https://timber.io/docs/languages/elixir/integrations/ecto) via [Timber Ecto](https://hex.pm/packages/timber_ecto)
   * [**Plug**](https://timber.io/docs/languages/elixir/integrations/plug) via [Timber Plug](https://hex.pm/packages/timber_plug)
 * Platforms
-  * **Exceptions** via [Timber Exceptions](https://hex.pm/packages/timber_excptions)
+  * **Exceptions** via [Timber Exceptions](https://hex.pm/packages/timber_exceptions)
   * [**System / Server**](https://timber.io/docs/languages/elixir/integrations/system)
 
 ...more coming soon! Make a request by [opening an issue](https://github.com/timberio/timber-elixir/issues/new)


### PR DESCRIPTION
Looks like a minor typo snuck in here, just changing `excption` to `exception`. I know that this whole readme sounds like it's going to be replaced soon from reading #313, but hopefully this is still a useful PR in the short-term.