### PR TITLE
Relax `:hackney` constraint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -186,7 +186,7 @@ defmodule Timber.Mixfile do
       # Hackney is pinned to known "safe" versions. While the pinned
       # versions below are _not_ guaranteed to be bug-free, they are
       # accepted by the community as stable.
-      {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9"},
+      {:hackney, "~> 1.9"},
       {:jason, "~> 1.1"},
       {:msgpax, "~> 2.0"},
 


### PR DESCRIPTION
This relaxes the `:hackney` constraint to `~> 1.9`. Hackney has since released up to `1.15.0` and we should not prevent users from upgrading. We've also been using `1.14.X` within Timber itself and it appears to be stable.