### PR TITLE
Remove unused HTTP methods

### DIFF
--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -100,4 +100,15 @@ defmodule Timber do
   def debug(io_device, message_fun) when is_function(message_fun) do
     IO.write(io_device, message_fun.())
   end
+
+  # Formats a duration, in milliseonds, to a human friendly representation
+  @doc false
+  def format_duration_ms(duration_ms) when is_integer(duration_ms),
+    do: [Integer.to_string(duration_ms), "ms"]
+
+  def format_duration_ms(duration_ms) when is_float(duration_ms) and duration_ms >= 1,
+    do: [:erlang.float_to_binary(duration_ms, decimals: 2), "ms"]
+
+  def format_duration_ms(duration_ms) when is_float(duration_ms) and duration_ms < 1,
+    do: [:erlang.float_to_binary(duration_ms * 1000, decimals: 0), "µs"]
 end

--- a/lib/timber/utils/http_events.ex
+++ b/lib/timber/utils/http_events.ex
@@ -31,17 +31,6 @@ defmodule Timber.Utils.HTTPEvents do
     |> URI.to_string()
   end
 
-  @doc false
-  # Attemps to grab the request ID from the headers
-  def get_request_id_from_headers(%{"x-request-id" => request_id}), do: request_id
-
-  def get_request_id_from_headers(%{"request-id" => request_id}), do: request_id
-
-  # Amazon uses their own *special* header
-  def get_request_id_from_headers(%{"x-amzn-requestid" => request_id}), do: request_id
-
-  def get_request_id_from_headers(_headers), do: nil
-
   # Move `:headers` (Map.t) into `:headers_json` (String.t) so that all headers are no indexed
   # within Timber by default.
   @spec move_headers_to_headers_json(Keyword.t()) :: Keyword.t()


### PR DESCRIPTION
This removes a number of method we used to normalize output for our `Plug` and `Phoenix` integrations. This is no longer necessary due to recent changes and if we do need these methods they should be moved to their integration libraries.