### PR TITLE
Handle :hackney breaking changes

### DIFF
--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -136,7 +136,7 @@ defmodule Timber do
     level = level |> Atom.to_string() |> String.upcase()
     message = message_fun.()
 
-    IO.write(io_device, [level, " ", message])
+    IO.puts(io_device, [level, ": ", message])
   end
 
   # Formats a duration, in milliseonds, to a human friendly representation

--- a/lib/timber/api.ex
+++ b/lib/timber/api.ex
@@ -13,6 +13,16 @@ defmodule Timber.API do
     request(api_key, :post, url, headers: headers, body: body, async: async)
   end
 
+  def handle_async_response(ref, msg) do
+    http_client = Config.http_client()
+    http_client.handle_async_response(ref, msg)
+  end
+
+  def wait_on_response(ref, timeout) do
+    http_client = Config.http_client()
+    http_client.wait_on_response(ref, timeout)
+  end
+
   #
   # Util
   #

--- a/lib/timber/http_client.ex
+++ b/lib/timber/http_client.ex
@@ -11,6 +11,16 @@ defmodule Timber.HTTPClient do
               {:ok, reference}
               | {:error, atom}
 
+  @callback handle_async_response(reference, term) ::
+              {:ok, status, body}
+              | {:error, atom}
+              | :pass
+
+  @callback wait_on_response(reference, timeout) ::
+              {:ok, status, body}
+              | {:error, atom}
+              | :timeout
+
   @callback request(method, url, headers, body) ::
               {:ok, integer, map, String.t()}
               | {:error, atom}

--- a/lib/timber/http_clients/fake.ex
+++ b/lib/timber/http_clients/fake.ex
@@ -53,6 +53,14 @@ defmodule Timber.HTTPClients.Fake do
     end
   end
 
+  def handle_async_response(_ref, _msg) do
+    :pass
+  end
+
+  def wait_on_response(_ref, _timeout) do
+    :pass
+  end
+
   def request(method, url, headers, body) do
     add_function_call(:request, {method, url, headers, body})
     stub = get_stub(:request)


### PR DESCRIPTION
Oh `:hackney` how I long that you were managed properly.

This change updates our asynchronous message handling to handle `:hackney`'s new format. This also moves message handling into the HTTP client since this is `:hackney` specific