### PR TITLE
Switch to `async: true` instead of `async: :once` since it causes memory issues

### DIFF
--- a/lib/timber/http_client.ex
+++ b/lib/timber/http_client.ex
@@ -12,12 +12,12 @@ defmodule Timber.HTTPClient do
               | {:error, atom}
 
   @callback handle_async_response(reference, term) ::
-              {:ok, status, body}
+              {:ok, status}
               | {:error, atom}
               | :pass
 
   @callback wait_on_response(reference, timeout) ::
-              {:ok, status, body}
+              {:ok, status}
               | {:error, atom}
               | :timeout
 

--- a/lib/timber/http_clients/hackney.ex
+++ b/lib/timber/http_clients/hackney.ex
@@ -33,7 +33,7 @@ defmodule Timber.HTTPClients.Hackney do
 
     req_opts =
       get_request_options()
-      |> Keyword.merge(async: :once)
+      |> Keyword.merge(async: true)
 
     :hackney.request(method, url, req_headers, body, req_opts)
   end
@@ -42,12 +42,17 @@ defmodule Timber.HTTPClients.Hackney do
   @impl HTTPClient
   # Legacy response structure for older versions of `:hackney`
   def handle_async_response(ref, {:hackney_response, ref, {:ok, status, body}}) do
-    {:ok, status, body}
+    {:ok, status}
   end
 
   # New response structure for current versions of `:hackney`
   def handle_async_response(ref, {:hackney_response, ref, {:status, status, body}}) do
-    {:ok, status, body}
+    {:ok, status}
+  end
+
+  # New response structure for current versions of `:hackney`
+  def handle_async_response(ref, {:hackney_response, ref, {:status, status}}) do
+    {:ok, status}
   end
 
   # Return errors since that conforms to the spec


### PR DESCRIPTION
This fixes a memory issue with a dependency library (`:hackney`) where setting the `async: :once` option causes memory to continually grow. Using `async: true` does not have this same effect.