### PR TITLE
timber_exceptions should probably install v2, as v1 does not have Timber.Exceptions.Translator

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -99,7 +99,7 @@ end
 ```elixir
 # mix.exs
 
-{:timber_exceptions, "~> 1.0"}
+{:timber_exceptions, "~> 2.0"}
 ```
 
 ```diff


### PR DESCRIPTION
See headline