### PR TITLE
Add link to upgrade guide in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 3.0.0 - 2018-12-20
 
+3.0.0 contains breaking changes, for upgrade instructions see [UPGRADING.md](./UPGRADING.md)
+
 ### Changed
 
   - [Jason](https://hex.pm/packages/jason) is now used for JSON encoding. The


### PR DESCRIPTION
Add link to upgrade guide in changelog because I had no idea that the upgrade guide existed before I searched the issues. Not 100% sure if the relative link will work, but I think it will.