### PR TITLE
Support new Timber API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+  - Added support for the new Timber API keys. The `:source_id` parameter is now supported when
+    configuring `:timber` in addition to the `:api_key`. This does not break backwards
+    compatibility.
+
 ## [3.1.0] - 2019-02-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The result: Beautiful, fast, powerful Elixir logging.
       backends: [Timber.LoggerBackends.HTTP],
 
     config :timber,
-      api_key: "{{your-api-key}}"
+      api_key: "YOUR_API_KEY",
+      source_id: "YOUR_SOURCE_ID"
     ```
 
 4. Test the pipes with:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,9 @@ This documents outlines how to upgrade from major versions of Timber
 Timber 3.x ships with a new library structure, including removing all integrations with dependencies like Phoenix, Ecto, and Plug into their own packages.  This will allow for better dependency management and compilation guarantees.  Many of the changes were internal, but upgrading does require a handful changes.
 
 ### Update Timber
+
 To start, simply update your Timber dep in mix.exs:
+
 ```elixir
 {:timber, "~> 3.0"}
 ```

--- a/lib/mix/tasks/test_the_pipes.ex
+++ b/lib/mix/tasks/test_the_pipes.ex
@@ -115,12 +115,13 @@ defmodule Mix.Tasks.Timber.TestThePipes do
     puts("Verifying log delivery to the Timber API")
 
     api_key = Config.api_key()
+    source_id = Config.source_id()
     message = "Testing the pipes (click the inspect icon to view more details)"
     log_entry = LogEntry.new(Timber.Utils.Timestamp.now(), :debug, message)
     log_map = LogEntry.to_map!(log_entry)
     body = Msgpax.pack!([log_map])
 
-    case API.send_logs(api_key, "application/msgpack", body) do
+    case API.send_logs(api_key, source_id, "application/msgpack", body) do
       {:ok, status, _headers, _body} when status in 200..299 ->
         puts("Logs successfully sent! View them at https://app.timber.io", :success)
         :ok

--- a/lib/timber/config.ex
+++ b/lib/timber/config.ex
@@ -22,17 +22,22 @@ defmodule Timber.Config do
   alias Timber.HTTPClients.Hackney, as: HackneyHTTPClient
 
   @application :timber
-  @default_http_url "https://logs.timber.io/frames"
+  @default_host "https://logs.timber.io"
 
   @doc """
   Your Timber application API key.
 
-  This can be obtained after you create your account in https://app.timber.io
+  This can be obtained after you create your account & source in https://app.timber.io
 
   ## Example
 
       config :timber,
         api_key: "abcd1234"
+
+  You can also use a `{:system, "TIMBER_API_KEY"}` tuple if you prefer environment variables.
+
+      config :timber,
+        api_key: {:system, "TIMBER_API_KEY"}
 
   """
   def api_key do
@@ -105,23 +110,54 @@ defmodule Timber.Config do
   Alternate URL for delivering logs. This is helpful if you want to use a proxy,
   for example.
 
-  Default: #{@default_http_url}
+  Default: #{@default_host}
 
   ## Example
 
-      config :timber, :http_url, "#{@default_http_url}"
+      config :timber, :http_host, "#{@default_host}"
+
+  You can also use a `{:system, "TIMBER_HOST"}` tuple if you prefer environment variables.
+
+      config :timber,
+        http_host: {:system, "TIMBER_HOST"}
 
   """
-  def http_url do
-    case Application.get_env(@application, :http_url, @default_http_url) do
+  def http_host do
+    case Application.get_env(@application, :http_host, @default_host) do
       {:system, env_var_name} ->
         get_env_with_warning(env_var_name)
 
-      http_url when is_binary(http_url) ->
-        http_url
+      http_host when is_binary(http_host) ->
+        http_host
 
       _else ->
         nil
+    end
+  end
+
+  @doc """
+  Your Timber source ID.
+
+  This can be obtained after you create your account & source in https://app.timber.io
+
+  ## Example
+
+      config :timber,
+        source_id: "1234"
+
+  You can also use a `{:system, "TIMBER_SOURCE_ID"}` tuple if you prefer environment variables.
+
+      config :timber,
+        source_id: {:system, "TIMBER_SOURCE_ID"}
+
+  """
+  def source_id do
+    case Application.get_env(@application, :source_id) do
+      {:system, env_var_name} ->
+        get_env_with_warning(env_var_name)
+
+      source_id ->
+        source_id
     end
   end
 


### PR DESCRIPTION
The new Timber API keys are not source specific, the source ID must be specified separately. This change updates the Timber library to take a `:source_id` configuration paramter in addition to the new API key. If a `:source_id` is supplied it is assumed the API key supplied follows the new format, otherwise the legacy API key method will be used. This ensures we do not break backwards compatibility.