### PR TITLE
Handle hackney argument error

### DIFF
--- a/lib/timber/http_clients/hackney.ex
+++ b/lib/timber/http_clients/hackney.ex
@@ -38,7 +38,7 @@ defmodule Timber.HTTPClients.Hackney do
     try do
       :hackney.request(method, url, req_headers, body, req_opts)
     rescue
-        e in ArgumentError -> {:error, "An ArgumentError occured with hackney: #{inspect e}"}
+      e in ArgumentError -> {:error, "An ArgumentError occured with hackney: #{inspect(e)}"}
     end
   end
 

--- a/lib/timber/http_clients/hackney.ex
+++ b/lib/timber/http_clients/hackney.ex
@@ -35,7 +35,11 @@ defmodule Timber.HTTPClients.Hackney do
       get_request_options()
       |> Keyword.merge(async: true)
 
-    :hackney.request(method, url, req_headers, body, req_opts)
+    try do
+      :hackney.request(method, url, req_headers, body, req_opts)
+    rescue
+        e in ArgumentError -> {:error, "An ArgumentError occured with hackney: #{inspect e}"}
+    end
   end
 
   @doc false


### PR DESCRIPTION
When running Logger.info/1 in a remote console, hackney seems to throw
an argument error when making a request. This is a workaround.

Addresses #346