### PR TITLE
Adds `to_event` support for arbitrary structs

### DIFF
--- a/test/lib/timber/eventable_test.exs
+++ b/test/lib/timber/eventable_test.exs
@@ -1,7 +1,7 @@
 defmodule Timber.EventableTest do
   use Timber.TestCase
 
-  alias Timber.Eventable
+  alias Timber.{Eventable, TestStruct}
 
   describe "Timber.Eventable.to_event/1" do
     test "map with a single root key" do
@@ -29,6 +29,15 @@ defmodule Timber.EventableTest do
                  message: "boom",
                  name: "RuntimeError"
                }
+             }
+    end
+
+    test "struct" do
+      struct = %TestStruct{}
+      event = Eventable.to_event(struct)
+
+      assert event == %{
+               test_struct: %{life: 42}
              }
     end
   end

--- a/test/support/test_struct.ex
+++ b/test/support/test_struct.ex
@@ -1,0 +1,4 @@
+defmodule Timber.TestStruct do
+  @moduledoc false
+  defstruct life: 42
+end


### PR DESCRIPTION
Adds the ability to send structs as events in log metadata:

```elixir
Logger.info("Something happened", event: %AnEvent{with_data: true})
```

Right now, doing this raises an exception and the log message is dropped:

```elixir
(FunctionClauseError) no function clause matching in Timber.Eventable.Any.to_event/1
```

### Use case

I'm using struct events in my project to represent something happening in the app and its associated data. In the event handler for those events, I'm adding the event itself as context to all logging. It doesn't work though, because Timber can't convert it.

This PR uses the struct name as the context namespace for its logged contents.