### PR TITLE
Fix typespec on add_context since keyword is a valid type

### DIFF
--- a/lib/timber.ex
+++ b/lib/timber.ex
@@ -35,7 +35,7 @@ defmodule Timber do
 
   See `add_context/2`
   """
-  @spec add_context(map()) :: :ok
+  @spec add_context(map() | keyword()) :: :ok
   def add_context(data, location \\ :local)
 
   @doc """
@@ -44,7 +44,7 @@ defmodule Timber do
   The second parameter indicates where you want the context to be
   stored. See `context_location` for more details.
   """
-  @spec add_context(map(), context_location) :: :ok
+  @spec add_context(map() | keyword(), context_location) :: :ok
   def add_context(data, :local) do
     LocalContext.add(data)
   end

--- a/lib/timber/local_context.ex
+++ b/lib/timber/local_context.ex
@@ -16,7 +16,7 @@ defmodule Timber.LocalContext do
   `Timber.Context.add/2` is called to merge the existing context
   with the provided context.
   """
-  @spec add(map()) :: :ok
+  @spec add(map() | keyword()) :: :ok
   def add(context) do
     load()
     |> Context.merge(context)


### PR DESCRIPTION
Fixes #348 

Updates typespec on `add_context` to include `keyword()`